### PR TITLE
test(search): cover user role filter

### DIFF
--- a/tests/Feature/SearchUsersTest.php
+++ b/tests/Feature/SearchUsersTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Role;
 
 uses(RefreshDatabase::class);
 
@@ -135,6 +136,17 @@ it('validates user search order_direction', function () {
 
     $response->assertStatus(422)
         ->assertJsonValidationErrors(['order_direction']);
+});
+
+it('can filter users by role', function () {
+    $editor = Role::create(['name' => 'editor']);
+    $this->user1->assignRole($editor);
+
+    $response = $this->getJson('/api/search/users?role=editor');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(1, 'data')
+        ->assertJsonFragment(['email' => 'alice@example.com']);
 });
 
 it('can combine multiple user filters', function () {


### PR DESCRIPTION
Adds a regression test for the `?role=` filter in `SearchService::searchUsers`.

## Why
A docs audit flagged `SearchService:26` (`$query->role()`) as a missing-scope bug. Verified false: `User` uses Spatie `HasRoles` (User.php:32), which provides `scopeRole()`. The filter works — but had **no test coverage**, so a future regression would be silent.

## Change
- `tests/Feature/SearchUsersTest.php`: new "can filter users by role" — assigns a role, queries `/api/search/users?role=editor`, asserts only that user returns.

## Verification
- `vendor/bin/pest tests/Feature/SearchUsersTest.php` → 12 passed (40 assertions)
- `vendor/bin/pint` clean