### PR TITLE
feat(admin): add Account Settings tab to user form

### DIFF
--- a/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
+++ b/app/Filament/Admin/Resources/Users/Schemas/UserForm.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\Users\Schemas;
 
+use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
@@ -73,6 +74,26 @@ class UserForm
                                             ->placeholder('Select roles')
                                             ->helperText('Users inherit all permissions from their assigned roles')
                                             ->columnSpanFull(),
+                                    ]),
+                            ]),
+
+                        Tab::make('Account Settings')
+                            ->schema([
+                                Section::make('Account')
+                                    ->description('Email verification and team context')
+                                    ->columns(2)
+                                    ->schema([
+                                        DateTimePicker::make('email_verified_at')
+                                            ->label('Email Verified At')
+                                            ->helperText('Set to mark the email as verified; clear to revoke.'),
+
+                                        Select::make('current_team_id')
+                                            ->label('Current Team')
+                                            ->relationship('latestTeam', 'name')
+                                            ->searchable()
+                                            ->preload()
+                                            ->placeholder('No active team')
+                                            ->helperText('The team this user is currently acting within.'),
                                     ]),
                             ]),
 

--- a/tests/Feature/AdminUserAccountSettingsTest.php
+++ b/tests/Feature/AdminUserAccountSettingsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Filament\Admin\Resources\Users\Pages\EditUser;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->team = Team::factory()->create();
+    $this->admin = User::factory()->create(['current_team_id' => $this->team->id]);
+
+    // Bypass Shield/policy gates — this test covers the form schema, not authorization.
+    Gate::before(fn () => true);
+
+    $this->actingAs($this->admin);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($this->team);
+});
+
+it('saves account settings: email verified at and current team', function () {
+    $target = User::factory()->create(['email_verified_at' => null]);
+
+    Livewire::test(EditUser::class, ['record' => $target->getRouteKey()])
+        ->fillForm([
+            'email_verified_at' => now()->startOfMinute(),
+            'current_team_id' => $this->team->id,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $target->refresh();
+
+    expect($target->email_verified_at)->not->toBeNull()
+        ->and($target->current_team_id)->toBe($this->team->id);
+});


### PR DESCRIPTION
Builds the third `UserForm` tab documented in `ADMIN_PANEL_ENHANCEMENTS.md` (and referenced by QUICK_REFERENCE / FINAL_REPORT) but never implemented — the form shipped with only 2 tabs.

## Change
`app/Filament/Admin/Resources/Users/Schemas/UserForm.php` — new **Account Settings** tab:
- **Email Verified At** — `DateTimePicker` to manually verify/revoke (field already fillable + datetime cast).
- **Current Team** — `Select` via the `latestTeam` relationship. `current_team_id` is *not* fillable, so a relationship select is used (sets the FK directly, bypassing mass-assignment).

> Note: the model's `current_team_id` belongsTo is named `latestTeam()`, not `currentTeam()` — Jetstream's `HasTeams` was removed to avoid a Spatie trait conflict (see User.php:37).

## Verification
- New `tests/Feature/AdminUserAccountSettingsTest.php`: edits a user via the `EditUser` Livewire page, asserts both fields persist. Green.
- `vendor/bin/pest tests/Feature/{FilamentPanelAccessTest,AdminUserAccountSettingsTest}.php` → 4 passed
- `vendor/bin/pint` clean · `vendor/bin/phpstan analyse` (level 5) clean