### PR TITLE
feat(modules): prove internachi Layer 1 with Ping module

### DIFF
--- a/app-modules/Ping/composer.json
+++ b/app-modules/Ping/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "modules/ping",
+    "description": "Ping Module",
+    "type": "library",
+    "autoload": {
+        "psr-4": {
+            "Modules\\Ping\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Ping\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Modules\\Ping\\Providers\\PingServiceProvider"
+            ]
+        }
+    }
+}

--- a/app-modules/Ping/config/Ping.php
+++ b/app-modules/Ping/config/Ping.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'enabled' => true,
+    'version' => '1.0.0',
+];

--- a/app-modules/Ping/database/migrations/2026_06_29_102459_create_pings_table.php
+++ b/app-modules/Ping/database/migrations/2026_06_29_102459_create_pings_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pings', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pings');
+    }
+};

--- a/app-modules/Ping/resources/views/index.blade.php
+++ b/app-modules/Ping/resources/views/index.blade.php
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Ping Module</title>
+</head>
+<body>
+    <h1>Welcome to Ping Module</h1>
+</body>
+</html>

--- a/app-modules/Ping/routes/api.php
+++ b/app-modules/Ping/routes/api.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Ping\Http\Controllers\PingController;
+
+Route::middleware(['api'])->prefix('api')->group(function () {
+    Route::get('/ping', [PingController::class, 'index']);
+});

--- a/app-modules/Ping/routes/web.php
+++ b/app-modules/Ping/routes/web.php
@@ -1,0 +1,8 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Ping\Http\Controllers\PingController;
+
+Route::middleware(['web'])->group(function () {
+    Route::get('/ping', [PingController::class, 'index'])->name('ping.index');
+});

--- a/app-modules/Ping/src/Http/Controllers/PingController.php
+++ b/app-modules/Ping/src/Http/Controllers/PingController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Modules\Ping\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+class PingController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return view('ping::index');
+    }
+}

--- a/app-modules/Ping/src/Models/Ping.php
+++ b/app-modules/Ping/src/Models/Ping.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Modules\Ping\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Ping extends Model
+{
+    protected $fillable = [];
+}

--- a/app-modules/Ping/src/PingModule.php
+++ b/app-modules/Ping/src/PingModule.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Modules\Ping;
+
+class PingModule
+{
+    /**
+     * Get the module name.
+     */
+    public static function getName(): string
+    {
+        return 'Ping';
+    }
+
+    /**
+     * Get the module version.
+     */
+    public static function getVersion(): string
+    {
+        return '1.0.0';
+    }
+
+    /**
+     * Get the module description.
+     */
+    public static function getDescription(): string
+    {
+        return 'Ping Module';
+    }
+}

--- a/app-modules/Ping/src/Providers/PingServiceProvider.php
+++ b/app-modules/Ping/src/Providers/PingServiceProvider.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Modules\Ping\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class PingServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        // Register module services
+        $this->mergeConfigFrom(
+            __DIR__.'/../../config/Ping.php',
+            strtolower('Ping')
+        );
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        // Load routes
+        $this->loadRoutesFrom(__DIR__.'/../../routes/web.php');
+
+        // Load migrations
+        $this->loadMigrationsFrom(__DIR__.'/../../database/migrations');
+
+        // Load views
+        $this->loadViewsFrom(__DIR__.'/../../resources/views', strtolower('Ping'));
+
+        // Load translations
+        $this->loadTranslationsFrom(__DIR__.'/../../resources/lang', strtolower('Ping'));
+
+        // Publish config
+        $this->publishes([
+            __DIR__.'/../../config/Ping.php' => config_path(strtolower('Ping').'.php'),
+        ], 'Ping-config');
+
+        // Publish migrations
+        $this->publishes([
+            __DIR__.'/../../database/migrations' => database_path('migrations'),
+        ], 'Ping-migrations');
+
+        // Publish views
+        $this->publishes([
+            __DIR__.'/../../resources/views' => resource_path('views/vendor/'.strtolower('Ping')),
+        ], 'Ping-views');
+    }
+}

--- a/app-modules/Ping/tests/Feature/PingTest.php
+++ b/app-modules/Ping/tests/Feature/PingTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Modules\Ping\Tests\Feature;
+
+use Tests\TestCase;
+
+class PingTest extends TestCase
+{
+    public function test_module_index(): void
+    {
+        $response = $this->get(route('ping.index'));
+        $response->assertStatus(200);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "spatie/laravel-passkeys": "^1.6",
         "spatie/laravel-permission": "^7.0",
         "spiral/roadrunner-cli": "^2.6.0",
-        "spiral/roadrunner-http": "^3.3.0"
+        "spiral/roadrunner-http": "^3.3.0",
+        "wikimedia/composer-merge-plugin": "^2.1"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",
@@ -81,6 +82,11 @@
     "extra": {
         "laravel": {
             "dont-discover": []
+        },
+        "merge-plugin": {
+            "include": [
+                "app-modules/*/composer.json"
+            ]
         }
     },
     "config": {
@@ -94,7 +100,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "wikimedia/composer-merge-plugin": true
         }
     },
     "audit": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1e5e228e7a211ff3c97f351910768d9",
+    "content-hash": "1e988a7622da74b20753bf919ba7f4d0",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -14814,6 +14814,62 @@
                 "source": "https://github.com/webmozarts/assert/tree/2.4.1"
             },
             "time": "2026-06-15T15:31:57+00:00"
+        },
+        {
+            "name": "wikimedia/composer-merge-plugin",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/wikimedia/composer-merge-plugin.git",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/wikimedia/composer-merge-plugin/zipball/a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "reference": "a03d426c8e9fb2c9c569d9deeb31a083292788bc",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1||^2.0",
+                "php": ">=7.2.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.1||^2.0",
+                "ext-json": "*",
+                "mediawiki/mediawiki-phan-config": "0.11.1",
+                "php-parallel-lint/php-parallel-lint": "~1.3.1",
+                "phpspec/prophecy": "~1.15.0",
+                "phpunit/phpunit": "^8.5||^9.0",
+                "squizlabs/php_codesniffer": "~3.7.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Wikimedia\\Composer\\Merge\\V2\\MergePlugin",
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Wikimedia\\Composer\\Merge\\V2\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bryan Davis",
+                    "email": "bd808@wikimedia.org"
+                }
+            ],
+            "description": "Composer plugin to merge multiple composer.json files",
+            "support": {
+                "issues": "https://github.com/wikimedia/composer-merge-plugin/issues",
+                "source": "https://github.com/wikimedia/composer-merge-plugin/tree/v2.1.0"
+            },
+            "time": "2023-04-15T19:07:00+00:00"
         }
     ],
     "packages-dev": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Modules">
+            <directory>app-modules/*/tests</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>


### PR DESCRIPTION
Turns the dead internachi/modular scaffold into a working pipeline (audit task, see `scope.md`).

## Root cause
Layer 1 modules under `app-modules/` were never autoloaded: each module ships its own `composer.json` (`Modules\\X\\` → `src/`), but nothing merged those into the root autoloader. Result — module **routes** loaded, but their **classes** threw `Target class [...] does not exist`.

## Fix
- Add `wikimedia/composer-merge-plugin` + `extra.merge-plugin.include: app-modules/*/composer.json` (the setup internachi/modular documents) and allow the plugin.
- Add a `Modules` phpunit testsuite (`app-modules/*/tests`) so module tests run in CI — previously only `tests/Unit` + `tests/Feature` ran.
- Ship `app-modules/Ping` as the reference module: route → controller → view, with a feature test.

## Verification
- `vendor/bin/pest` → **236 passed** (607 assertions), incl. `Modules\Ping\Tests\Feature\PingTest`.
- `vendor/bin/pint app-modules/Ping` clean.

Layer 1 is now genuinely usable — `php artisan make:module X` produces a module that loads end to end.