### PR TITLE
fix(teams): restore User team helper methods

### DIFF
--- a/app/Http/Middleware/AssignDefaultTeam.php
+++ b/app/Http/Middleware/AssignDefaultTeam.php
@@ -12,7 +12,7 @@ class AssignDefaultTeam
     {
         if (! Filament::getTenant() && auth()->check()) {
             $user = auth()->user();
-            $defaultTeam = $user->currentTeam ?? $user->ownedTeams()->first();
+            $defaultTeam = $user->latestTeam ?? $user->ownedTeams()->first();
             if (! $defaultTeam) {
                 $defaultTeam = $user->ownedTeams()->create([
                     'name' => $user->name."'s Team",

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -46,6 +46,46 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     }
 
     /**
+     * Determine whether the user owns the given team.
+     */
+    public function ownsTeam(?Team $team): bool
+    {
+        if (is_null($team)) {
+            return false;
+        }
+
+        return $this->id === $team->user_id;
+    }
+
+    /**
+     * Determine whether the user owns or is a member of the given team.
+     */
+    public function belongsToTeam(?Team $team): bool
+    {
+        if (is_null($team)) {
+            return false;
+        }
+
+        return $this->ownsTeam($team)
+            || $this->teams->contains('id', $team->id);
+    }
+
+    /**
+     * Switch the user's current team, if they belong to it.
+     */
+    public function switchTeam(?Team $team): bool
+    {
+        if (! $this->belongsToTeam($team)) {
+            return false;
+        }
+
+        $this->forceFill(['current_team_id' => $team->id])->save();
+        $this->setRelation('latestTeam', $team);
+
+        return true;
+    }
+
+    /**
      * The attributes that are mass assignable.
      *
      * @var array<int, string>

--- a/tests/Unit/UserTeamMethodsTest.php
+++ b/tests/Unit/UserTeamMethodsTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('ownsTeam is true only for owned teams', function () {
+    $user = User::factory()->create();
+    $owned = Team::factory()->create(['user_id' => $user->id]);
+    $other = Team::factory()->create();
+
+    expect($user->ownsTeam($owned))->toBeTrue()
+        ->and($user->ownsTeam($other))->toBeFalse()
+        ->and($user->ownsTeam(null))->toBeFalse();
+});
+
+it('belongsToTeam covers owned and member teams', function () {
+    $user = User::factory()->create();
+    $owned = Team::factory()->create(['user_id' => $user->id]);
+    $member = Team::factory()->create();
+    $member->users()->attach($user, ['role' => 'editor']);
+    $stranger = Team::factory()->create();
+
+    expect($user->belongsToTeam($owned))->toBeTrue()
+        ->and($user->fresh()->belongsToTeam($member))->toBeTrue()
+        ->and($user->belongsToTeam($stranger))->toBeFalse();
+});
+
+it('switchTeam persists current team for members and rejects others', function () {
+    $user = User::factory()->create();
+    $owned = Team::factory()->create(['user_id' => $user->id]);
+    $stranger = Team::factory()->create();
+
+    expect($user->switchTeam($owned))->toBeTrue()
+        ->and($user->fresh()->current_team_id)->toBe($owned->id)
+        ->and($user->switchTeam($stranger))->toBeFalse();
+});


### PR DESCRIPTION
## Bug
Admin panel 500s: `Call to undefined method App\Models\User::ownsTeam()` at `TeamPolicy:42`.

## Root cause
Jetstream's `HasTeams` trait was removed from `User` (to avoid a Spatie conflict — User.php:37), but its methods were still called across the app. Only the relations (`ownedTeams`, `teams`, `latestTeam`) had been re-added.

## Fix
Re-add the specific helpers the app uses, backed by the manual relations:
- `ownsTeam()` — `id === team.user_id`
- `belongsToTeam()` — owns or in `team_user` pivot
- `switchTeam()` — sets `current_team_id` for members, returns false otherwise
- `AssignDefaultTeam` reads the existing `latestTeam` relation instead of the removed `currentTeam` accessor

Fixes every caller found by grep: `TeamPolicy` (×6), `CreateTeam`, `CreateNewUser`, `AssignDefaultTeam`.

## Verification
- New `tests/Unit/UserTeamMethodsTest.php` (3 tests) — reproduced the `BadMethodCallException` (red), now green.
- Full suite: **238 passed** (615 assertions).
- `pint` clean. `phpstan` (level 5): no new errors from this change (User.php carries 4 pre-existing larastan model-rule warnings on `$fillable`/`$hidden`/`$appends`/`profile_photo_url`, unrelated to this fix).