### PR TITLE
fix(shield): don't tenant-scope roles when teams disabled

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -11,6 +11,7 @@ use App\Models\MenuItem as MenuItemModel;
 use App\Models\Team;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use BezhanSalleh\FilamentShield\Middleware\SyncShieldTenant;
+use BezhanSalleh\FilamentShield\Support\Utils;
 use Biostate\FilamentMenuBuilder\FilamentMenuBuilderPlugin;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -91,7 +92,10 @@ class AdminPanelProvider extends PanelProvider
 
         $panel->plugins([
             FilamentShieldPlugin::make()
-                ->navigationGroup('Administration'),
+                ->navigationGroup('Administration')
+                // Roles are global unless Spatie teams are enabled; without this
+                // the tenant-scoped panel tries to resolve Role->team() and 500s.
+                ->scopeToTenant(Utils::isTenancyEnabled()),
             FilamentMenuBuilderPlugin::make()
                 ->usingMenuModel(Menu::class)
                 ->usingMenuItemModel(MenuItemModel::class)

--- a/tests/Feature/ShieldRoleResourceTenancyTest.php
+++ b/tests/Feature/ShieldRoleResourceTenancyTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
+use BezhanSalleh\FilamentShield\Support\Utils;
+use Filament\Facades\Filament;
+
+it('does not tenant-scope the shield role resource when teams are disabled', function () {
+    // permission.teams is off in this app, so roles are global. If the resource
+    // stays tenant-scoped, Filament tries Role->team() and 500s the admin panel.
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    expect(Utils::isTenancyEnabled())->toBeFalse()
+        ->and(RoleResource::isScopedToTenant())->toBeFalse();
+});


### PR DESCRIPTION
## Bug
Admin panel 500s: `The model [App\Models\Role] does not have a relationship named [team]` (Filament `BelongsToTenant`), hit on the Shield Roles page.

## Root cause
The admin panel is tenant-scoped (`->tenant(Team::class, ownershipRelationship: 'team')`), so by default **every** resource — including Shield's `RoleResource` — is scoped to the tenant and Filament tries to resolve `Role->team()`. But `permission.teams` is **off** (`MULTITENANCY=false`): roles are global, the roles table has no `team_id`, and `Role` has no `team()` relationship. (`UserResource` avoids this by setting `$tenantOwnershipRelationshipName = 'teams'`, which `User` actually has.)

## Fix
Shield's `RoleResource` reads its tenant-scoping from the plugin (filament-plugin-essentials). Drive it from the real teams flag:
```php
FilamentShieldPlugin::make()->scopeToTenant(Utils::isTenancyEnabled())
```
- Teams off → `false`: roles are global, no tenant scope, panel works.
- Teams on → `true`: scoping returns automatically (would then also need a `Role->team()` relationship — out of scope here).

## Verification
- New `tests/Feature/ShieldRoleResourceTenancyTest.php`: asserts `isTenancyEnabled()` is false and `RoleResource::isScopedToTenant()` is false under the admin panel. Failed before the fix (default `true`), green after.
- End-to-end: `RoleResource::getEloquentQuery()->count()` under the panel+tenant ran cleanly (previously threw).
- Full suite: **240 passed**. `pint` clean. `phpstan`: no new errors (AdminPanelProvider carries 1 pre-existing Fortify `login()` type error, unrelated).