### PR TITLE
fix(admin): opt global resources out of tenant scoping

### DIFF
--- a/app/Filament/Admin/Resources/GroupResource.php
+++ b/app/Filament/Admin/Resources/GroupResource.php
@@ -19,6 +19,9 @@ class GroupResource extends Resource
 {
     protected static ?string $model = Group::class;
 
+    // Groups are global content (no team relationship); don't tenant-scope them.
+    protected static bool $isScopedToTenant = false;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-user-group';
 
     protected static string|\UnitEnum|null $navigationGroup = 'Content';

--- a/app/Filament/Admin/Resources/MenuItemResource.php
+++ b/app/Filament/Admin/Resources/MenuItemResource.php
@@ -7,4 +7,7 @@ use Biostate\FilamentMenuBuilder\Filament\Resources\MenuItemResource as BaseMenu
 class MenuItemResource extends BaseMenuItemResource
 {
     protected static bool $shouldRegisterNavigation = false;
+
+    // Menu items are global (no team relationship); don't tenant-scope them.
+    protected static bool $isScopedToTenant = false;
 }

--- a/app/Filament/Admin/Resources/MenuResource.php
+++ b/app/Filament/Admin/Resources/MenuResource.php
@@ -6,6 +6,9 @@ use Biostate\FilamentMenuBuilder\Filament\Resources\MenuResource as BaseMenuReso
 
 class MenuResource extends BaseMenuResource
 {
+    // Menus are global (no team relationship); don't tenant-scope them.
+    protected static bool $isScopedToTenant = false;
+
     public static function getNavigationGroup(): ?string
     {
         return null;

--- a/app/Filament/Admin/Resources/PostResource.php
+++ b/app/Filament/Admin/Resources/PostResource.php
@@ -19,6 +19,9 @@ class PostResource extends Resource
 {
     protected static ?string $model = Post::class;
 
+    // Posts are global content (no team relationship); don't tenant-scope them.
+    protected static bool $isScopedToTenant = false;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
 
     protected static string|\UnitEnum|null $navigationGroup = 'Content';

--- a/tests/Feature/AdminResourceTenancyTest.php
+++ b/tests/Feature/AdminResourceTenancyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Filament\Admin\Resources\GroupResource;
+use App\Filament\Admin\Resources\GroupResource\Pages\ListGroups;
+use App\Filament\Admin\Resources\MenuItemResource;
+use App\Filament\Admin\Resources\MenuResource;
+use App\Filament\Admin\Resources\PostResource;
+use App\Filament\Admin\Resources\PostResource\Pages\ListPosts;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+// These models have no team relationship, so under the tenant-scoped admin
+// panel they must opt out of tenancy or Filament 500s resolving Model->team().
+it('opts global resources out of tenant scoping', function () {
+    expect(PostResource::isScopedToTenant())->toBeFalse()
+        ->and(GroupResource::isScopedToTenant())->toBeFalse()
+        ->and(MenuResource::isScopedToTenant())->toBeFalse()
+        ->and(MenuItemResource::isScopedToTenant())->toBeFalse();
+});
+
+it('renders the posts and groups lists under the tenant panel', function () {
+    $team = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->id]);
+
+    Gate::before(fn () => true);
+    $this->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($team);
+
+    Livewire::test(ListPosts::class)->assertOk();
+    Livewire::test(ListGroups::class)->assertOk();
+});


### PR DESCRIPTION
## Bug
Admin resource pages 500: `The model [App\Models\Post] does not have a relationship named [team]` (Filament `BelongsToTenant`). Reported for Posts; same root cause affects Groups, Menus, Menu Items.

## Root cause
The panel is tenant-scoped (`->tenant(Team::class, ownershipRelationship: 'team')`), so **every** resource is tenant-scoped by default. `Post`, `Group`, `Menu`, `MenuItem` have no `team` relationship (and no `team_id` — `MULTITENANCY=false`, so they're global content), so Filament throws when it tries to resolve `Model->team()`. Same family as the Shield roles fix (#569); swept proactively rather than one 500 at a time.

## Fix
`protected static bool $isScopedToTenant = false;` on:
- `PostResource`, `GroupResource` (app resources)
- `MenuResource`, `MenuItemResource` (override the Biostate base)

`UserResource` is left tenant-scoped — it correctly uses `$tenantOwnershipRelationshipName = 'teams'`, which `User` has. `ModuleResource` (no model, array data source) and `LanguageSettingsResource` (no model) are unaffected.

## Verification
- New `tests/Feature/AdminResourceTenancyTest.php`: asserts all four resources report `isScopedToTenant() === false` (red before, green after), and renders the Posts + Groups lists under the tenant panel.
- Full suite: **243 passed**. `pint` + `phpstan` (level 5) clean.