### PR TITLE
fix(user): add Socialstream HasConnectedAccounts trait

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use JoelButcher\Socialstream\HasConnectedAccounts;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Sanctum\HasApiTokens;
@@ -25,6 +26,7 @@ use Spatie\Permission\Traits\HasRoles;
 class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasPasskeys, HasTenants
 {
     use HasApiTokens;
+    use HasConnectedAccounts;
     use HasFactory;
     use HasProfilePhoto {
         HasProfilePhoto::profilePhotoUrl as getPhotoUrl;

--- a/tests/Feature/ConnectedAccountsTest.php
+++ b/tests/Feature/ConnectedAccountsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+// The connected-accounts profile view calls ->map()/->where() on
+// $user->connectedAccounts; without the Socialstream relationship it is null.
+it('exposes the connectedAccounts relationship', function () {
+    $user = User::factory()->create();
+
+    expect($user->connectedAccounts)->toBeInstanceOf(Collection::class)
+        ->and($user->connectedAccounts)->toHaveCount(0);
+});


### PR DESCRIPTION
## Bug
`Call to a member function map() on null` — `resources/views/profile/connected-accounts-form.blade.php`. The view operates on `$user->connectedAccounts`, which was null.

## Root cause
`User` never used Socialstream's `JoelButcher\Socialstream\HasConnectedAccounts` trait (same omission pattern as the stripped Jetstream `HasTeams`), so the `connectedAccounts` relationship didn't exist — accessing it returned null, and the form's `->where()`/`->map()` blew up. The `connected_accounts` table already exists.

## Fix
Add the `HasConnectedAccounts` trait to `User` (provides the `connectedAccounts` HasMany + `ownsConnectedAccount`/`hasTokenFor`/`getTokenFor` helpers). No method conflicts with the existing profile-photo / roles / passkeys traits.

## Verification
- New `tests/Feature/ConnectedAccountsTest.php`: `$user->connectedAccounts` is an empty Collection (was null → red, green after).
- Full suite: **266 passed**.
- `pint` clean; `phpstan` (level 5): no new errors (User.php's 4 pre-existing `$fillable`/`$hidden`/`$appends`/`profile_photo_url` warnings are unchanged).