### PR TITLE
Phase 1: site settings + Shield team-tenancy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,8 +90,15 @@ is **not yet ported** — it is Phase 4 work.
 - **Horizon** manages Redis queues; dashboard at `/horizon`.
 - **Octane + RoadRunner** provides the HTTP server in production (config in `.rr.yaml`).
 
-### Permissions Model
-Spatie Permission roles/permissions are team-scoped (multi-tenancy). `FilamentShield` auto-generates policies for each Filament resource. The `Permission` and `Role` models extend Spatie's defaults. Policy classes are in `app/Policies/`.
+### Permissions Model (Phase 1 — done)
+Spatie Permission roles/permissions are team-scoped (`config/permission.php` `teams => true`, models point at `App\Models\Role`/`Permission`). `FilamentShield` auto-generates policies per Filament resource. Policy classes in `app/Policies/`.
+
+**Filament tenancy rules (important):**
+- The **admin** panel is Team-tenant-scoped (`->tenant(Team::class)`); the **app** panel is intentionally **not** scoped. `User`'s tenancy methods (`getTenants` = owned + member teams, `canAccessTenant`, `getDefaultTenant`) are panel-agnostic.
+- Any Filament Resource whose model has **no `team()` relationship** MUST override `public static function isScopedToTenant(): bool { return false; }`, or the tenant panel **500s** on that resource. Shield's global `RoleResource` is handled via `FilamentShieldPlugin::make()->scopeToTenant(Utils::isTenancyEnabled())`.
+- With `permission.teams=true`, roles carry a `team_id`, so `shield:generate` / super-admin assignment must run **inside a team context** (set `setPermissionsTeamId($team->id)` in a seeder, or scope the command). Default shield config has `super_admin.define_via_gate=false` — a bare `super_admin` role grants nothing until permissions are generated.
+- `User` resolves the `HasRoles::teams` vs `HasTeams::teams` trait collision by keeping Jetstream's `teams()` (`insteadof`) and excluding Spatie's (Spatie scopes via the `team_id` column, not that relation).
+- **Known:** `User::canAccessPanel()` returns `true` (any authenticated user reaches `/admin`); per-resource Shield policies still gate each resource. Tighten to a role check in a later auth-hardening phase.
 
 ### Theme System
 Themes live under `themes/{name}/` with their own CSS/JS/views. The active theme is resolved by `ThemeManager` (`app/Services/ThemeManager.php`) and set per user via `theme_preference` on the users table. Blade directives and helpers are registered in `ThemeServiceProvider`. Vite is configured to build per-theme assets (currently commented out pending re-enablement via `glob`).

--- a/README.md
+++ b/README.md
@@ -1,58 +1,489 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400" alt="Laravel Logo"></a></p>
+# Liberu Software — Laravel 13 SaaS Boilerplate
 
-<p align="center">
-<a href="https://github.com/laravel/framework/actions"><img src="https://github.com/laravel/framework/workflows/tests/badge.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+[![](https://avatars.githubusercontent.com/u/158830885?s=200&v=4)](https://www.liberu.co.uk)
 
-## About Laravel
+![](https://img.shields.io/badge/PHP-8.5-informational?style=flat&logo=php&color=4f5b93)
+![](https://img.shields.io/badge/Laravel-13-informational?style=flat&logo=laravel&color=ef3b2d)
+![](https://img.shields.io/badge/Filament-5-informational?style=flat&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0OCIgaGVpZ2h0PSI0OCIgeG1sbnM6dj0iaHR0cHM6Ly92ZWN0YS5pby9uYW5vIj48cGF0aCBkPSJNMCAwaDQ4djQ4SDBWMHoiIGZpbGw9IiNmNGIyNWUiLz48cGF0aCBkPSJNMjggN2wtMSA2LTMuNDM3LjgxM0wyMCAxNWwtMSAzaDZ2NWgtN2wtMyAxOEg4Yy41MTUtNS44NTMgMS40NTQtMTEuMzMgMy0xN0g4di01bDUtMSAuMjUtMy4yNUMxNCAxMSAxNCAxMSAxNS40MzggOC41NjMgMTkuNDI5IDYuMTI4IDIzLjQ0MiA2LjY4NyAyOCA3eiIgZmlsbD0iIzI4MjQxZSIvPjxwYXRoIGQ9Ik0zMCAxOGg0YzIuMjMzIDUuMzM0IDIuMjMzIDUuMzM0IDEuMTI1IDguNUwzNCAyOWMtLjE2OCAzLjIwOS0uMTY4IDMuMjA5IDAgNmwtMiAxIDEgM2gtNXYyaC0yYy44NzUtNy42MjUuODc1LTcuNjI1IDItMTFoMnYtMmgtMnYtMmwyLTF2LTQtM3oiIGZpbGw9IiMyYTIwMTIiLz48cGF0aCBkPSJNMzUuNTYzIDYuODEzQzM4IDcgMzggNyAzOSA4Yy4xODggMi40MzguMTg4IDIuNDM4IDAgNWwtMiAyYy0yLjYyNS0uMzc1LTIuNjI1LS4zNzUtNS0xLS42MjUtMi4zNzUtLjYyNS0yLjM3NS0xLTUgMi0yIDItMiA0LjU2My0yLjE4N3oiIGZpbGw9IiM0MDM5MzEiLz48cGF0aCBkPSJNMzAgMThoNGMyLjA1NSA1LjMxOSAyLjA1NSA1LjMxOSAxLjgxMyA4LjMxM0wzNSAyOGwtMyAxdi0ybC00IDF2LTJsMi0xdi00LTN6IiBmaWxsPSIjMzEyODFlIi8+PHBhdGggZD0iTTI5IDI3aDN2MmgydjJoLTJ2MmwtNC0xdi0yaDJsLTEtM3oiIGZpbGw9IiMxNTEzMTAiLz48cGF0aCBkPSJNMzAgMThoNHYzaC0ydjJsLTMgMSAxLTZ6IiBmaWxsPSIjNjA0YjMyIi8+PC9zdmc+&&color=fdae4b&link=https://filamentphp.com)
+![](https://img.shields.io/badge/Livewire-4-informational?style=flat&logo=Livewire&color=fb70a9)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+![Open Source Love](https://img.shields.io/badge/Open%20Source-%E2%9D%A4-red.svg)
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+## Build modern SaaS applications faster — a production-ready Laravel 13 boilerplate powered by PHP 8.5, Filament 5 and Livewire 4.
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+[![Contact us on WhatsApp](https://img.shields.io/badge/WhatsApp-25D366?style=for-the-badge&logo=whatsapp&logoColor=white)](https://wa.me/+441793200950)
+[![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://www.youtube.com/@liberusoftware)
+[![Facebook](https://img.shields.io/badge/Facebook-%231877F2.svg?style=for-the-badge&logo=Facebook&logoColor=white)](https://www.facebook.com/liberusoftware)
+[![Instagram](https://img.shields.io/badge/Instagram-%23E4405F.svg?style=for-the-badge&logo=Instagram&logoColor=white)](https://www.instagram.com/liberusoftware)
+[![X](https://img.shields.io/badge/X-%23000000.svg?style=for-the-badge&logo=X&logoColor=white)](https://www.x.com/liberusoftware)
+[![LinkedIn](https://img.shields.io/badge/linkedin-%230077B5.svg?style=for-the-badge&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/liberugroup)
+[![GitHub](https://img.shields.io/badge/github-%23121011.svg?style=for-the-badge&logo=github&logoColor=white)](https://www.github.com/liberusoftware)
 
-## Learning Laravel
 
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
+[![Install](https://github.com/liberusoftware/boilerplate-laravel/actions/workflows/install.yml/badge.svg)](https://github.com/liberusoftware/boilerplate-laravel/actions/workflows/install.yml)
+[![Tests](https://github.com/liberusoftware/boilerplate-laravel/actions/workflows/tests.yml/badge.svg)](https://github.com/liberusoftware/boilerplate-laravel/actions/workflows/tests.yml)
+[![Docker](https://github.com/liberusoftware/boilerplate-laravel/actions/workflows/main.yml/badge.svg)](https://github.com/liberusoftware/boilerplate-laravel/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/liberusoftware/boilerplate-laravel/graph/badge.svg?token=K7TWB1QF1L)](https://codecov.io/gh/liberusoftware/boilerplate-laravel)
+[![Latest Release](https://img.shields.io/github/v/release/liberusoftware/boilerplate-laravel?label=Latest%20Release)](https://github.com/liberusoftware/boilerplate-laravel/releases/latest)
 
-In addition, [Laracasts](https://laracasts.com) contains thousands of video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
+A production-ready SaaS starter built with Laravel 13, PHP 8.5, Filament 5, Livewire 4, Jetstream and Socialite — designed to kickstart multi-tenant or single-tenant SaaS applications with minimal setup.
 
-You can also watch bite-sized lessons with real-world projects on [Laravel Learn](https://laravel.com/learn), where you will be guided through building a Laravel application from scratch while learning PHP fundamentals.
+Website: https://www.liberu.co.uk
 
-## Agentic Development
+---
 
-Laravel's predictable structure and conventions make it ideal for AI coding agents like Claude Code, Cursor, and GitHub Copilot. Install [Laravel Boost](https://laravel.com/docs/ai) to supercharge your AI workflow:
+Table of contents
+- Overview
+- Key features
+- Prerequisites
+- Standard (local) install
+- Automated installation script
+- Web-based graphical installer
+- Docker / Sail install
+- Running tests
+- Troubleshooting
+- Contributing
+- License
+
+---
+
+Overview
+--------
+**Liberu Software** is an open-source initiative that combines the latest versions of Laravel 13, PHP 8.5, Filament 5 and Livewire 4 to provide a solid, extensible foundation for modern web applications. This boilerplate ships with the common SaaS building blocks you need — authentication, an admin panel, real-time interactivity, social login, notifications, multi-language support and more — so you can focus on building your product rather than reinventing the wheel.
+
+Whether you are starting a new SaaS product, an internal tool, or a modular enterprise application, this boilerplate is designed to get you productive from day one. It follows Laravel best practices, supports both single-tenant and multi-tenant patterns, and is fully containerised for Docker or Kubernetes deployments.
+
+**Private Messaging System** — a complete secure messaging feature is built in, allowing users to exchange end-to-end encrypted messages. See [MESSAGING.md](docs/MESSAGING.md) and [SETUP_MESSAGING.md](docs/SETUP_MESSAGING.md) for full documentation.
+
+**Multi-Language Support** — the application supports English, Spanish, French and German out of the box with automated translations, smart language detection and per-user preferences. See [docs/MULTI_LANGUAGE.md](docs/MULTI_LANGUAGE.md) for details.
+
+Key features
+------------
+- Jetstream authentication and user profiles with avatar uploads
+- Filament admin panel for resource management
+- Livewire-powered UI for reactive components
+- Social login via Socialite
+- **Real-time notifications with Pusher/Laravel Echo** (see [docs/NOTIFICATIONS.md](docs/NOTIFICATIONS.md))
+- **Modular architecture** for easy custom module integration
+- **Custom Theme System** - Support for custom layouts, CSS, and JS per theme (see [docs/THEME_SYSTEM.md](docs/THEME_SYSTEM.md))
+- **Private Messaging System** - Secure end-to-end encrypted messaging between users
+- **Multi-Language Support** - Automated translations with language detection and user preferences (see [docs/MULTI_LANGUAGE.md](docs/MULTI_LANGUAGE.md))
+- Database seeders and example data (optional)
+- Docker and Laravel Sail support for containerized development
+
+Prerequisites
+-------------
+- PHP 8.5
+- Composer
+- Node.js (recommended: LTS) and npm or yarn (for front-end assets)
+- MySQL / PostgreSQL or another supported DB
+- Docker (if using Docker or Sail)
+
+Standard (local) install
+------------------------
+> **Quickstart:** The fastest way to get started is to use the bundled `install.sh` script (see *Automated installation script* below) or the browser-based graphical installer at `public/installer.php`. Both options guide you step-by-step without requiring manual configuration.
+
+These steps assume you want to run the application on your machine (not in Docker). They are intentionally clear and safe — back up any existing .env before overriding.
+
+1. Clone the repo
+   ```bash
+   git clone https://github.com/liberusoftware/boilerplate-laravel.git
+   cd boilerplate-laravel
+   ```
+
+2. Install PHP dependencies
+   ```bash
+   composer install
+   ```
+
+3. Copy the example env and configure
+   ```bash
+   cp .env.example .env
+   # Edit .env to set DB_*, APP_URL and other settings
+   ```
+
+4. Generate application key
+   ```bash
+   php artisan key:generate
+   ```
+
+5. Install front-end dependencies (if you plan to build assets)
+   ```bash
+   npm install
+   # or
+   yarn
+   ```
+
+6. Build front-end assets (development or production)
+   ```bash
+   npm run dev   # development
+   npm run build # production
+   ```
+
+7. Run migrations and seeders
+    - IMPORTANT: Seeders will add example data. Skip seeding if you don't want that.
+   ```bash
+   php artisan migrate
+   # When you want seed data:
+   php artisan migrate --seed
+   ```
+
+8. Create storage symlink (required for profile photos)
+   ```bash
+   php artisan storage:link
+   ```
+
+9. Run the application
+   ```bash
+   php artisan serve --host=127.0.0.1 --port=8000
+   ```
+   Open: http://127.0.0.1:8000 (or your configured APP_URL)
+
+Automated installation script
+-----------------------------
+The repository includes `install.sh`, an interactive shell script that automates the entire setup process. Run it from the command line after cloning:
 
 ```bash
-composer require laravel/boost --dev
-
-php artisan boost:install
+chmod +x install.sh
+./install.sh
 ```
 
-Boost provides your agent 15+ tools and skills that help agents build Laravel applications while following best practices.
+The script supports three installation modes:
+1. **Standalone** - Local development/production installation
+2. **Docker** - Containerised deployment
+3. **Kubernetes** - K8s cluster deployment
 
-## Contributing
+Features of `install.sh`:
+- Automatically detects and handles missing dependencies
+- Downloads `composer.phar` if the `composer` command is not available
+- Skips `composer install` if the `vendor/` folder already exists
+- Skips `npm install` if the `node_modules/` folder already exists
+- Provides coloured output and error checking
+- Interactive prompts guide you through configuration step by step
 
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
+Web-based graphical installer
+------------------------------
+A browser-based graphical installer is available at `public/installer.php` for users who prefer a point-and-click setup experience. Enable it before use:
 
-## Code of Conduct
+```dotenv
+INSTALLER_ENABLED=true
+INSTALLER_KEY=your-secret-key   # optional: restrict access
+```
 
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
+The graphical installer provides:
+- **Step-by-step installation workflow** with visual progress indicators
+- Composer and NPM installation with automatic skip if already installed
+- **Fallback to download `composer.phar`** if the `composer` command is not found
+- Database configuration and connectivity testing
+- Migration and seeding
+- User creation with role assignment
+- **Module management** (list, install, enable modules)
+- **"Run All Steps" button** for fully automated one-click installation
 
-## Security Vulnerabilities
+> **Important:** Disable the installer after setup by setting `INSTALLER_ENABLED=false` in `.env`.
 
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
+Notes
+- Configure mail and social provider settings in `.env` for production use.
+- If you use a different DB (e.g., PostgreSQL), update `.env` accordingly.
 
-## License
+Docker install
+--------------
+Two recommended Docker approaches are provided: manual Docker image and Laravel Sail.
 
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+A. Using the repository Dockerfile (image build)
+1. Build the image from the project root:
+   ```bash
+   docker build -t boilerplate-laravel .
+   ```
+2. Create an env file for the container or use your `.env`:
+   ```bash
+   # Ensure .env contains correct DB and APP_URL values
+   ```
+3. Run the container (example: mapped port 8000):
+   ```bash
+   docker run --name boilerplate-app --env-file .env -p 8000:8000 -d boilerplate-laravel
+   ```
+4. Run migrations inside the running container:
+   ```bash
+   docker exec -it boilerplate-app php artisan migrate --seed
+   docker exec -it boilerplate-app php artisan storage:link
+   ```
+5. Visit: http://localhost:8000
+
+Notes for Docker image:
+- When building a standalone image, ensure your Dockerfile handles running queue workers, scheduler, and any entrypoint tasks you need. For development, using docker run with volume mounts can be more convenient.
+
+B. Recommended: Use Laravel Sail (Docker Compose wrapper)
+1. Start Sail from project root:
+   ```bash
+   # Linux / macOS
+   ./vendor/bin/sail up -d
+   # Windows (PowerShell)
+   vendor/bin/sail up -d
+   ```
+2. Run migrations and seeders using Sail:
+   ```bash
+   ./vendor/bin/sail artisan migrate --seed
+   ./vendor/bin/sail artisan storage:link
+   ```
+3. Build front-end assets inside Sail (if needed):
+   ```bash
+   ./vendor/bin/sail npm install
+   ./vendor/bin/sail npm run dev
+   ```
+4. Visit: http://localhost
+
+Sail notes:
+- Sail creates a complete development environment with services (DB, Redis, mailhog) and is the recommended containerized development workflow.
+
+Running tests
+-------------
+This repository includes automated tests (see /tests). Run tests with:
+
+```bash
+# Local (uses Pest)
+composer install --dev
+vendor/bin/pest
+
+# Or via Laravel's test runner which proxies to Pest
+php artisan test
+
+# With Sail
+./vendor/bin/sail test
+```
+
+Troubleshooting
+---------------
+- "Permission denied" when running storage or bootstrap cache: adjust filesystem ownership
+  ```bash
+  sudo chown -R $USER:www-data storage bootstrap/cache
+  chmod -R 775 storage bootstrap/cache
+  ```
+- DB connection errors: verify `.env` DB_* values and ensure the DB service is running (Sail or local).
+- If assets not updating: clear caches
+  ```bash
+  php artisan config:clear
+  php artisan cache:clear
+  php artisan view:clear
+  ```
+
+Modular Architecture
+--------------------
+This boilerplate features a powerful modular architecture based on the **internachi/modular** pattern, allowing you to easily create and integrate custom modules for specific project requirements. The system integrates seamlessly with Filament 5 and supports custom themes.
+
+### Quick Start with Modules
+
+Create a new module:
+```bash
+php artisan make:module YourModule
+# or
+php artisan module create YourModule
+```
+
+Manage modules:
+```bash
+php artisan module list              # List all modules
+php artisan module enable MyModule   # Enable a module
+php artisan module disable MyModule  # Disable a module
+php artisan module install MyModule  # Install a module (migrations + enable)
+php artisan module info MyModule     # Show module information
+```
+
+### Module Features
+
+- **Composer-based autoloading** - Each module is autoloaded as a composer package
+- **Laravel package discovery** - Automatic service provider registration
+- **Filament 5 integration** - Auto-discovery of Filament resources, pages, and widgets
+- **Self-contained structure** - Each module has its own controllers, models, views, routes, migrations, and configuration
+- **Lifecycle hooks** - Enable, disable, install, and uninstall hooks for custom logic
+- **Dependency management** - Declare dependencies on other modules
+- **Custom theme support** - Modules can provide their own themes and assets
+- **Auto-discovery** - Modules are automatically discovered and registered
+- **Configuration management** - Easy configuration with dedicated config files
+- **Database migrations** - Automatic migration running during installation
+- **Asset publishing** - Assets are automatically published to public directory
+- **IDE-friendly** - Full autocomplete and code navigation support
+
+### Documentation
+
+- [Module Development Guide](docs/MODULE_DEVELOPMENT.md) - Comprehensive guide for developing custom modules
+- [Quick Start Guide](docs/MODULE_QUICK_START.md) - Get started with modules in minutes
+- Example modules in `app-modules/` and `app/Modules/BlogModule/` - Reference implementations
+
+### Module Structure
+
+```
+app-modules/YourModule/
+├── composer.json                  # Module composer configuration
+├── src/
+│   ├── YourModuleModule.php      # Main module class
+│   ├── Providers/
+│   │   └── YourModuleServiceProvider.php
+│   ├── Http/Controllers/
+│   ├── Models/
+│   ├── Services/
+│   ├── Filament/                 # Filament 5 resources (auto-discovered)
+│   │   ├── Resources/
+│   │   ├── Pages/
+│   │   └── Widgets/
+├── routes/
+│   ├── web.php
+│   ├── api.php
+│   └── admin.php
+├── database/migrations/
+├── resources/
+│   ├── views/
+│   ├── lang/
+│   └── assets/
+└── tests/
+```
+
+### Filament 5 Integration
+
+Modules automatically integrate with Filament 5:
+- Place Filament resources in `src/Filament/Resources/`
+- Create custom pages in `src/Filament/Pages/`
+- Add widgets in `src/Filament/Widgets/`
+- All components are auto-discovered and registered
+
+### Custom Theme Support
+
+Modules can provide custom themes:
+- Define themes in `resources/themes/`
+- Include custom layouts, CSS, and JavaScript
+- Themes integrate with the application theme system
+- Support for theme inheritance and overrides
+
+Custom Theme System
+-------------------
+This boilerplate includes a comprehensive theme system that allows you to create custom layouts, CSS, and JavaScript for different visual themes.
+
+### Quick Start with Themes
+
+Switch themes programmatically:
+```php
+set_theme('dark');  // Switch to dark theme
+$current = active_theme();  // Get current theme
+```
+
+Use the theme switcher component:
+```blade
+<livewire:theme-switcher />
+```
+
+### Theme Features
+
+- **Custom Layouts** - Theme-specific Blade layouts in `/themes/{theme}/views/`
+- **Custom CSS** - Theme-specific stylesheets in `/themes/{theme}/css/app.css`
+- **Custom JavaScript** - Theme-specific scripts in `/themes/{theme}/js/app.js`
+- **User Preferences** - Themes saved to database per user or session
+- **Dynamic Switching** - Switch themes on the fly with Livewire component
+- **Fallback System** - Automatically falls back to default files if theme doesn't have custom versions
+- **Blade Directives** - `@themeCss`, `@themeJs`, `@themeAsset()`, `@themeLayout()`
+
+### Using Themes in Views
+
+```blade
+{{-- Use theme-specific layout --}}
+@extends(theme_layout('app'))
+
+@section('content')
+    {{-- Include theme CSS and JS --}}
+    @themeCss
+    @themeJs
+    
+    {{-- Use theme assets --}}
+    <img src="{{ theme_asset('images/logo.png') }}" alt="Logo">
+@endsection
+```
+
+### Creating a New Theme
+
+1. Create theme directories:
+```bash
+mkdir -p themes/mytheme/views/layouts
+mkdir -p themes/mytheme/css
+mkdir -p themes/mytheme/js
+```
+
+2. Create `theme.json` with metadata
+3. Create custom layout files
+4. Create custom CSS and JS
+5. Build assets: `npm run build`
+
+### Documentation
+
+- [Theme System Guide](docs/THEME_SYSTEM.md) - Complete guide for creating and using themes
+- Example themes: `themes/default/` and `themes/dark/`
+
+### Theme Structure
+
+```
+themes/
+└── mytheme/
+    ├── theme.json           # Theme metadata
+    ├── views/
+    │   └── layouts/
+    │       └── app.blade.php    # Custom layout
+    ├── css/
+    │   └── app.css              # Theme CSS
+    └── js/
+        └── app.js               # Theme JavaScript
+```
+
+Contributing
+------------
+Contributions are welcome and warmly encouraged! To contribute:
+
+1. **Fork** the repository on GitHub
+2. **Create a feature branch** from `main` — e.g. `git checkout -b feature/my-improvement`
+3. **Make your changes** and add or update tests where applicable
+4. **Ensure tests pass** by running `php artisan test` or `vendor/bin/pest`
+5. **Commit** with a clear, descriptive message
+6. **Open a Pull Request** against the `main` branch — describe what you changed and why
+
+Please follow the repository's code style. All pull requests are reviewed before merging. If you are planning a large change, consider opening an issue first to discuss it with the maintainers.
+
+We welcome bug fixes, new features, documentation improvements and translations. Cross-repo collaboration with other Liberu projects is especially encouraged.
+
+License
+-------
+This project is licensed under the **MIT License** — see the [LICENSE](LICENSE) file for the full text.
+
+The MIT license is one of the most permissive open-source licenses available. Key benefits:
+
+- **Free to use** in personal, commercial and proprietary projects at no cost
+- **Free to modify** — you can adapt the code to your needs without restriction
+- **Free to distribute** — you may share, sell or sublicense the software
+- **No warranty obligations** — you are not required to provide support or maintenance
+- **Patent peace** — no hidden patent grants or restrictions
+- **Business-friendly** — the only requirement is to retain the original copyright notice and license text
+
+In short: take this boilerplate, build your product and ship it — the license will not get in your way.
+
+Credits & Related Projects
+--------------------------
+- Liberu Software: https://www.liberu.co.uk
+
+## Related projects
+
+The Liberu ecosystem contains a number of companion repositories and packages that extend or demonstrate functionality used in this boilerplate. Below is a concise, professional list of those projects with quick descriptions — follow the links to learn more or to contribute.
+
+| Project | Repository | Short description |
+|---|---:|---|
+| Accounting | [liberu-accounting/accounting-laravel](https://github.com/liberu-accounting/accounting-laravel) | Accounting and invoicing features tailored for Laravel applications. |
+| Automation | [liberu-automation/automation-laravel](https://github.com/liberu-automation/automation-laravel) | Automation tooling and workflow integrations for Laravel projects. |
+| Billing | [liberu-billing/billing-laravel](https://github.com/liberu-billing/billing-laravel) | Subscription and billing management integrations (payments, invoices). |
+| Boilerplate (core) | [liberusoftware/boilerplate](https://github.com/liberusoftware/boilerplate) | Core starter and shared utilities used across Liberu projects. |
+| Browser Game | [liberu-browser-game/browser-game-laravel](https://github.com/liberu-browser-game/browser-game-laravel) | Example Laravel-based browser game platform and mechanics. |
+| CMS | [liberu-cms/cms-laravel](https://github.com/liberu-cms/cms-laravel) | Content management features and modular page administration. |
+| Control Panel | [liberu-control-panel/control-panel-laravel](https://github.com/liberu-control-panel/control-panel-laravel) | Administration/control-panel components for managing services. |
+| CRM | [liberu-crm/crm-laravel](https://github.com/liberu-crm/crm-laravel) | Customer relationship management features and integrations. |
+| E‑commerce | [liberu-ecommerce/ecommerce-laravel](https://github.com/liberu-ecommerce/ecommerce-laravel) | E‑commerce storefront, product and order management. |
+| Genealogy | [liberu-genealogy/genealogy-laravel](https://github.com/liberu-genealogy/genealogy-laravel) | Family tree and genealogy features built on Laravel. |
+| Maintenance | [liberu-maintenance/maintenance-laravel](https://github.com/liberu-maintenance/maintenance-laravel) | Scheduling, tracking and reporting for maintenance tasks. |
+| Real Estate | [liberu-real-estate/real-estate-laravel](https://github.com/liberu-real-estate/real-estate-laravel) | Property listings and real-estate management features. |
+| Social Network | [liberu-social-network/social-network-laravel](https://github.com/liberu-social-network/social-network-laravel) | Social features, profiles, feeds and messaging for Laravel apps. |
+
+If you maintain or use one of these projects and would like a more detailed description or a different categorisation, open an issue or submit a pull request and we'll update the list. Contributions and cross-repo collaboration are warmly encouraged.

--- a/app/Filament/Pages/ManageSiteSettings.php
+++ b/app/Filament/Pages/ManageSiteSettings.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Filament\Pages;
+
+use App\Settings\SiteSettings;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Pages\SettingsPage;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class ManageSiteSettings extends SettingsPage
+{
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
+
+    protected static string $settings = SiteSettings::class;
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Settings';
+
+    protected static ?string $title = 'Site Settings';
+
+    protected static ?string $navigationLabel = 'Site Settings';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(1)
+            ->components([
+                Section::make('Site Information')
+                    ->schema([
+                        TextInput::make('site_name')
+                            ->label('Site Name')
+                            ->required()
+                            ->maxLength(255),
+                        TextInput::make('site_email')
+                            ->label('Site Email')
+                            ->email()
+                            ->required()
+                            ->maxLength(255),
+                        TextInput::make('site_phone')
+                            ->label('Site Phone')
+                            ->tel()
+                            ->maxLength(255),
+                        TextInput::make('site_address')
+                            ->label('Site Address')
+                            ->maxLength(255),
+                        TextInput::make('site_country')
+                            ->label('Country')
+                            ->maxLength(255),
+                        TextInput::make('site_currency')
+                            ->label('Currency Symbol')
+                            ->maxLength(10),
+                        TextInput::make('site_default_language')
+                            ->label('Default Language')
+                            ->maxLength(10)
+                            ->default('en'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Social Media Links')
+                    ->description('Add your social media profile URLs')
+                    ->schema([
+                        TextInput::make('facebook_url')
+                            ->label('Facebook URL')
+                            ->url()
+                            ->maxLength(255),
+                        TextInput::make('twitter_url')
+                            ->label('Twitter URL')
+                            ->url()
+                            ->maxLength(255),
+                        TextInput::make('github_url')
+                            ->label('GitHub URL')
+                            ->url()
+                            ->maxLength(255),
+                        TextInput::make('youtube_url')
+                            ->label('YouTube URL')
+                            ->url()
+                            ->maxLength(255),
+                    ])
+                    ->columns(2),
+
+                Section::make('Footer')
+                    ->schema([
+                        Textarea::make('footer_copyright')
+                            ->label('Copyright Text')
+                            ->required()
+                            ->maxLength(500)
+                            ->rows(2),
+                    ]),
+            ]);
+    }
+}

--- a/app/Models/Membership.php
+++ b/app/Models/Membership.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Laravel\Jetstream\Membership as JetstreamMembership;
+
+class Membership extends JetstreamMembership
+{
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     *
+     * @var bool
+     */
+    public $incrementing = true;
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Spatie\Permission\Models\Permission as SpatiePermission;
+
+class Permission extends SpatiePermission
+{
+    //
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Spatie\Permission\Models\Role as SpatieRole;
+
+class Role extends SpatieRole
+{
+    //
+}

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Laravel\Jetstream\TeamInvitation as JetstreamTeamInvitation;
+
+class TeamInvitation extends JetstreamTeamInvitation
+{
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'email',
+        'role',
+    ];
+
+    /**
+     * Get the team that the invitation belongs to.
+     *
+     * @return BelongsTo<Team, $this>
+     */
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,8 +3,15 @@
 namespace App\Models;
 
 use Database\Factories\UserFactory;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Models\Contracts\HasDefaultTenant;
+use Filament\Models\Contracts\HasTenants;
+use Filament\Panel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use JoelButcher\Socialstream\HasConnectedAccounts;
@@ -13,8 +20,9 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Jetstream\HasTeams;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
-class User extends Authenticatable
+class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasTenants
 {
     use HasApiTokens;
     use HasConnectedAccounts;
@@ -25,7 +33,13 @@ class User extends Authenticatable
     use HasProfilePhoto {
         HasProfilePhoto::profilePhotoUrl as getPhotoUrl;
     }
-    use HasTeams;
+    use HasRoles, HasTeams {
+        // Both traits define teams(): Jetstream = team membership (used by allTeams()
+        // and Filament tenancy); Spatie = teams-derived-from-roles (convenience only,
+        // never called internally). Keep Jetstream's; alias Spatie's out of the way.
+        HasTeams::teams insteadof HasRoles;
+        HasRoles::teams as spatieRoleTeams;
+    }
     use Notifiable;
     use SetsProfilePhotoFromUrl;
     use TwoFactorAuthenticatable;
@@ -81,5 +95,38 @@ class User extends Authenticatable
         return filter_var($this->profile_photo_path, FILTER_VALIDATE_URL)
             ? Attribute::get(fn () => $this->profile_photo_path)
             : $this->getPhotoUrl();
+    }
+
+    /**
+     * The teams this user may act within as a Filament tenant.
+     *
+     * @return array<int, Model>|Collection<int, Model>
+     */
+    public function getTenants(Panel $panel): array|Collection
+    {
+        return $this->ownedTeams;
+    }
+
+    public function canAccessTenant(Model $tenant): bool
+    {
+        return $tenant instanceof Team && $this->belongsToTeam($tenant);
+    }
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
+    }
+
+    public function getDefaultTenant(Panel $panel): ?Model
+    {
+        return $this->latestTeam;
+    }
+
+    /**
+     * @return BelongsTo<Team, $this>
+     */
+    public function latestTeam(): BelongsTo
+    {
+        return $this->belongsTo(Team::class, 'current_team_id');
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,12 +8,12 @@ use Filament\Models\Contracts\HasDefaultTenant;
 use Filament\Models\Contracts\HasTenants;
 use Filament\Panel;
 use Illuminate\Database\Eloquent\Casts\Attribute;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use JoelButcher\Socialstream\HasConnectedAccounts;
 use JoelButcher\Socialstream\SetsProfilePhotoFromUrl;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -35,10 +35,9 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     }
     use HasRoles, HasTeams {
         // Both traits define teams(): Jetstream = team membership (used by allTeams()
-        // and Filament tenancy); Spatie = teams-derived-from-roles (convenience only,
-        // never called internally). Keep Jetstream's; alias Spatie's out of the way.
+        // and Filament tenancy). Spatie's teams() (roles-derived) is excluded — Spatie
+        // scopes via the team_id column + DefaultTeamResolver, not this relation.
         HasTeams::teams insteadof HasRoles;
-        HasRoles::teams as spatieRoleTeams;
     }
     use Notifiable;
     use SetsProfilePhotoFromUrl;
@@ -98,13 +97,14 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
     }
 
     /**
-     * The teams this user may act within as a Filament tenant.
+     * The teams this user may act within as a Filament tenant — owned + member teams,
+     * consistent with canAccessTenant()/belongsToTeam() so invited members aren't locked out.
      *
      * @return array<int, Model>|Collection<int, Model>
      */
     public function getTenants(Panel $panel): array|Collection
     {
-        return $this->ownedTeams;
+        return $this->allTeams();
     }
 
     public function canAccessTenant(Model $tenant): bool

--- a/app/Policies/TeamPolicy.php
+++ b/app/Policies/TeamPolicy.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class TeamPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Team $team): bool
+    {
+        return $user->belongsToTeam($team);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can add team members.
+     */
+    public function addTeamMember(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can update team member permissions.
+     */
+    public function updateTeamMember(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can remove team members.
+     */
+    public function removeTeamMember(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Team $team): bool
+    {
+        return $user->ownsTeam($team);
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers\Filament;
 
+use App\Models\Team;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
+use BezhanSalleh\FilamentShield\Middleware\SyncShieldTenant;
+use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -42,6 +45,10 @@ class AdminPanelProvider extends PanelProvider
                 AccountWidget::class,
                 FilamentInfoWidget::class,
             ])
+            ->tenant(Team::class, ownershipRelationship: 'team')
+            ->tenantMiddleware([
+                SyncShieldTenant::class,
+            ], isPersistent: true)
             ->middleware([
                 EncryptCookies::class,
                 AddQueuedCookiesToResponse::class,
@@ -54,7 +61,11 @@ class AdminPanelProvider extends PanelProvider
                 DispatchServingFilamentEvent::class,
             ])
             ->plugins([
-                FilamentShieldPlugin::make(),
+                // Roles are team-scoped only when Spatie teams are enabled; gating on
+                // Utils::isTenancyEnabled() keeps Shield's RoleResource from resolving a
+                // missing Role->team() relation (which would 500 the tenant panel).
+                FilamentShieldPlugin::make()
+                    ->scopeToTenant(Utils::isTenancyEnabled()),
             ])
             ->authMiddleware([
                 Authenticate::class,

--- a/app/Settings/SiteSettings.php
+++ b/app/Settings/SiteSettings.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Settings;
+
+use Spatie\LaravelSettings\Settings;
+
+class SiteSettings extends Settings
+{
+    public string $site_name;
+
+    public string $site_email;
+
+    public ?string $site_phone;
+
+    public ?string $site_address;
+
+    public ?string $site_country;
+
+    public string $site_currency;
+
+    public string $site_default_language;
+
+    public ?string $facebook_url;
+
+    public ?string $twitter_url;
+
+    public ?string $github_url;
+
+    public ?string $youtube_url;
+
+    public string $footer_copyright;
+
+    public static function group(): string
+    {
+        return 'site';
+    }
+}

--- a/config/permission.php
+++ b/config/permission.php
@@ -1,8 +1,8 @@
 <?php
 
+use App\Models\Permission;
+use App\Models\Role;
 use Spatie\Permission\DefaultTeamResolver;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 
 return [
 
@@ -148,7 +148,7 @@ return [
      * (view the latest version of this package's migration file)
      */
 
-    'teams' => false,
+    'teams' => true,
 
     /*
      * The class to use to resolve the permissions team id

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Settings\SiteSettings;
+use Spatie\LaravelData\Data;
+use Spatie\LaravelSettings\SettingsCasts\DataCast;
+use Spatie\LaravelSettings\SettingsCasts\DateTimeInterfaceCast;
+use Spatie\LaravelSettings\SettingsCasts\DateTimeZoneCast;
+use Spatie\LaravelSettings\SettingsRepositories\DatabaseSettingsRepository;
+use Spatie\LaravelSettings\SettingsRepositories\RedisSettingsRepository;
+
+return [
+
+    /*
+     * Each settings class used in your application must be registered, you can
+     * put them (manually) here.
+     */
+    'settings' => [
+        SiteSettings::class,
+    ],
+
+    /*
+     * The path where the settings classes will be created.
+     */
+    'setting_class_path' => app_path('Settings'),
+
+    /*
+     * In these directories settings migrations will be stored and ran when migrating. A settings
+     * migration created via the make:settings-migration command will be stored in the first path or
+     * a custom defined path when running the command.
+     */
+    'migrations_paths' => [
+        database_path('settings'),
+    ],
+
+    /*
+     * When no repository was set for a settings class the following repository
+     * will be used for loading and saving settings.
+     */
+    'default_repository' => 'database',
+
+    /*
+     * Settings will be stored and loaded from these repositories.
+     */
+    'repositories' => [
+        'database' => [
+            'type' => DatabaseSettingsRepository::class,
+            'model' => null,
+            'table' => null,
+            'connection' => null,
+        ],
+        'redis' => [
+            'type' => RedisSettingsRepository::class,
+            'connection' => null,
+            'prefix' => null,
+        ],
+    ],
+
+    /*
+     * The encoder and decoder will determine how settings are stored and
+     * retrieved in the database. By default, `json_encode` and `json_decode`
+     * are used.
+     */
+    'encoder' => null,
+    'decoder' => null,
+
+    /*
+     * The contents of settings classes can be cached through your application,
+     * settings will be stored within a provided Laravel store and can have an
+     * additional prefix.
+     */
+    'cache' => [
+        'enabled' => (bool) env('SETTINGS_CACHE_ENABLED', false),
+        'store' => null,
+        'prefix' => null,
+        'ttl' => null,
+
+        /*
+         * When enabled, uses Laravel's memoized cache driver (requires Laravel 12.9+)
+         * to keep resolved values in memory during a single request.
+         */
+        'memo' => env('SETTINGS_CACHE_MEMO', false),
+    ],
+
+    /*
+     * These global casts will be automatically used whenever a property within
+     * your settings class isn't a default PHP type.
+     */
+    'global_casts' => [
+        DateTimeInterface::class => DateTimeInterfaceCast::class,
+        DateTimeZone::class => DateTimeZoneCast::class,
+//        Spatie\DataTransferObject\DataTransferObject::class => Spatie\LaravelSettings\SettingsCasts\DtoCast::class,
+        Data::class => DataCast::class,
+    ],
+
+    /*
+     * The package will look for settings in these paths and automatically
+     * register them.
+     */
+    'auto_discover_settings' => [
+        app_path('Settings'),
+    ],
+
+    /*
+     * Automatically discovered settings classes can be cached, so they don't
+     * need to be searched each time the application boots up.
+     */
+    'discovered_settings_cache_path' => base_path('bootstrap/cache'),
+];

--- a/database/settings/2025_12_10_102854_create_site_settings.php
+++ b/database/settings/2025_12_10_102854_create_site_settings.php
@@ -1,0 +1,22 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class() extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('site.site_name', config('app.name', 'Liberu'));
+        $this->migrator->add('site.site_email', 'info@example.com');
+        $this->migrator->add('site.site_phone', '');
+        $this->migrator->add('site.site_address', '');
+        $this->migrator->add('site.site_country', '');
+        $this->migrator->add('site.site_currency', '$');
+        $this->migrator->add('site.site_default_language', 'en');
+        $this->migrator->add('site.facebook_url', null);
+        $this->migrator->add('site.twitter_url', null);
+        $this->migrator->add('site.github_url', 'https://github.com/liberusoftware/boilerplate-laravel');
+        $this->migrator->add('site.youtube_url', null);
+        $this->migrator->add('site.footer_copyright', '© '.date('Y').' '.config('app.name', 'Liberu').'. All rights reserved.');
+    }
+};

--- a/tests/Feature/AdminPanelTenancyTest.php
+++ b/tests/Feature/AdminPanelTenancyTest.php
@@ -1,15 +1,63 @@
 <?php
 
+use App\Models\Role;
 use App\Models\Team;
+use App\Models\User;
 use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+use Spatie\Permission\Models\Role as SpatieRole;
 
 it('scopes the admin panel to the Team tenant', function () {
     expect(Filament::getPanel('admin')->getTenantModel())->toBe(Team::class);
 });
 
-it('enables shield tenancy with the team_id column present (no 500 on role resolution)', function () {
+it('enables shield tenancy with the team_id column present', function () {
     expect(Utils::isTenancyEnabled())->toBeTrue()
         ->and(Schema::hasColumn('roles', 'team_id'))->toBeTrue();
+});
+
+it('exposes owned and member teams as Filament tenants', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $owner->id]);
+    $team->users()->attach($member, ['role' => 'editor']);
+    $member->forceFill(['current_team_id' => $team->id])->save();
+
+    // A non-owner member must still see the team as a tenant, or they get locked out.
+    expect($member->fresh()->getTenants(Filament::getPanel('admin'))->pluck('id'))
+        ->toContain($team->id)
+        ->and($member->fresh()->getDefaultTenant(Filament::getPanel('admin'))->getKey())
+        ->toBe($team->id);
+});
+
+it('renders the tenant-scoped Shield RoleResource without a 500', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $owner->id]);
+    $owner->forceFill(['current_team_id' => $team->id])->save();
+
+    setPermissionsTeamId($team->id);
+    $owner->assignRole(Role::create(['name' => 'super_admin', 'guard_name' => 'web']));
+    $editor = Role::create(['name' => 'editor', 'guard_name' => 'web']);
+
+    // Default shield config gates access via permissions, not a gate bypass; authorise
+    // for this render so the tenant-scoped table query actually executes.
+    Gate::before(fn ($user) => $user->hasRole('super_admin') ? true : null);
+
+    $this->actingAs($owner);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($team);
+
+    $roleResource = collect(Filament::getPanel('admin')->getResources())
+        ->first(fn (string $resource) => is_a($resource::getModel(), SpatieRole::class, true));
+
+    expect($roleResource)->not->toBeNull();
+
+    $listPage = $roleResource::getPages()['index']->getPage();
+
+    Livewire::test($listPage)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$editor]);
 });

--- a/tests/Feature/AdminPanelTenancyTest.php
+++ b/tests/Feature/AdminPanelTenancyTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use App\Models\Team;
+use BezhanSalleh\FilamentShield\Support\Utils;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Schema;
+
+it('scopes the admin panel to the Team tenant', function () {
+    expect(Filament::getPanel('admin')->getTenantModel())->toBe(Team::class);
+});
+
+it('enables shield tenancy with the team_id column present (no 500 on role resolution)', function () {
+    expect(Utils::isTenancyEnabled())->toBeTrue()
+        ->and(Schema::hasColumn('roles', 'team_id'))->toBeTrue();
+});

--- a/tests/Feature/ManageSiteSettingsPageTest.php
+++ b/tests/Feature/ManageSiteSettingsPageTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Filament\Pages\ManageSiteSettings;
+use App\Models\User;
+use App\Settings\SiteSettings;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    $this->actingAs(User::factory()->create());
+});
+
+it('renders the manage site settings page', function () {
+    Livewire::test(ManageSiteSettings::class)->assertOk();
+});
+
+it('persists site settings from the form', function () {
+    Livewire::test(ManageSiteSettings::class)
+        ->fillForm([
+            'site_name' => 'Acme',
+            'site_email' => 'info@acme.test',
+            'footer_copyright' => '© Acme',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    app()->forgetInstance(SiteSettings::class);
+
+    expect(app(SiteSettings::class)->site_name)->toBe('Acme');
+});

--- a/tests/Feature/SiteSettingsDefaultsTest.php
+++ b/tests/Feature/SiteSettingsDefaultsTest.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Settings\SiteSettings;
+
+it('seeds default site settings via the settings migration', function () {
+    $settings = app(SiteSettings::class);
+
+    expect($settings->site_currency)->toBe('$')
+        ->and($settings->site_default_language)->toBe('en')
+        ->and($settings->github_url)->toContain('github.com/liberusoftware');
+});

--- a/tests/Feature/SiteSettingsTest.php
+++ b/tests/Feature/SiteSettingsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Settings\SiteSettings;
+
+it('round-trips typed site settings through the container', function () {
+    $settings = app(SiteSettings::class);
+    $settings->site_name = 'Acme';
+    $settings->site_email = 'info@acme.test';
+    $settings->save();
+
+    app()->forgetInstance(SiteSettings::class);
+
+    $reloaded = app(SiteSettings::class);
+
+    expect($reloaded->site_name)->toBe('Acme')
+        ->and($reloaded->site_email)->toBe('info@acme.test');
+});

--- a/tests/Feature/TeamPolicyTest.php
+++ b/tests/Feature/TeamPolicyTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+
+it('lets an owner update and delete their team', function () {
+    $owner = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $owner->id]);
+
+    expect($owner->can('update', $team))->toBeTrue()
+        ->and($owner->can('delete', $team))->toBeTrue()
+        ->and($owner->can('addTeamMember', $team))->toBeTrue();
+});
+
+it('denies a stranger updating or deleting a team', function () {
+    $stranger = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => User::factory()->create()->id]);
+
+    expect($stranger->can('update', $team))->toBeFalse()
+        ->and($stranger->can('delete', $team))->toBeFalse();
+});
+
+it('allows viewing only for team members', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $stranger = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $owner->id]);
+    $team->users()->attach($member, ['role' => 'editor']);
+
+    expect($owner->can('view', $team))->toBeTrue()
+        ->and($member->fresh()->can('view', $team))->toBeTrue()
+        ->and($stranger->can('view', $team))->toBeFalse();
+});

--- a/tests/Feature/TeamPolicyTest.php
+++ b/tests/Feature/TeamPolicyTest.php
@@ -20,6 +20,20 @@ it('denies a stranger updating or deleting a team', function () {
         ->and($stranger->can('delete', $team))->toBeFalse();
 });
 
+it('denies member-management to non-owners', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $stranger = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $owner->id]);
+    $team->users()->attach($member, ['role' => 'editor']);
+
+    foreach (['addTeamMember', 'updateTeamMember', 'removeTeamMember'] as $ability) {
+        expect($member->fresh()->can($ability, $team))->toBeFalse()
+            ->and($stranger->can($ability, $team))->toBeFalse()
+            ->and($owner->can($ability, $team))->toBeTrue();
+    }
+});
+
 it('allows viewing only for team members', function () {
     $owner = User::factory()->create();
     $member = User::factory()->create();

--- a/tests/Feature/TeamScopedPermissionTest.php
+++ b/tests/Feature/TeamScopedPermissionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Schema;
+
+it('enables team-scoped permissions in config', function () {
+    expect(config('permission.teams'))->toBeTrue();
+});
+
+it('binds the app Role and Permission models', function () {
+    expect(config('permission.models.role'))->toBe(Role::class)
+        ->and(config('permission.models.permission'))->toBe(Permission::class)
+        ->and(new Role())->toBeInstanceOf(Spatie\Permission\Models\Role::class)
+        ->and(new Permission())->toBeInstanceOf(Spatie\Permission\Models\Permission::class);
+});
+
+it('adds team_id to the roles and pivot tables', function () {
+    expect(Schema::hasColumn('roles', 'team_id'))->toBeTrue()
+        ->and(Schema::hasColumn('model_has_roles', 'team_id'))->toBeTrue()
+        ->and(Schema::hasColumn('model_has_permissions', 'team_id'))->toBeTrue();
+});
+
+it('scopes a role to its team', function () {
+    $user = User::factory()->create();
+    $teamA = Team::factory()->create(['user_id' => $user->id]);
+    $teamB = Team::factory()->create(['user_id' => $user->id]);
+
+    setPermissionsTeamId($teamA->id);
+    $role = Role::create(['name' => 'editor', 'guard_name' => 'web']);
+    $user->assignRole($role);
+
+    expect($user->hasRole('editor'))->toBeTrue();
+
+    setPermissionsTeamId($teamB->id);
+
+    expect($user->fresh()->hasRole('editor'))->toBeFalse();
+});

--- a/tests/Unit/UserContractsTest.php
+++ b/tests/Unit/UserContractsTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use App\Models\User;
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Models\Contracts\HasDefaultTenant;
+use Filament\Models\Contracts\HasTenants;
+use Spatie\Permission\Traits\HasRoles;
+
+it('uses the Spatie HasRoles trait', function () {
+    expect(class_uses_recursive(User::class))->toContain(HasRoles::class)
+        ->and(method_exists(User::class, 'assignRole'))->toBeTrue();
+});
+
+it('implements the Filament tenancy contracts', function () {
+    $contracts = class_implements(User::class);
+
+    expect($contracts)->toContain(FilamentUser::class)
+        ->toContain(HasTenants::class)
+        ->toContain(HasDefaultTenant::class);
+});


### PR DESCRIPTION
## Phase 1 — Site settings + Shield team-tenancy

Stacks on #574 (Phase 0). Base is `chore/fresh-skeleton` for a clean Phase-1-only diff; rebase onto `main` once #574 merges.

Ported from `main` onto the fresh base, TDD throughout.

### Site settings (spatie/laravel-settings)
- Typed `App\Settings\SiteSettings` + `config/settings.php` registration + `database/settings` seed migration
- `App\Filament\Pages\ManageSiteSettings` (relocated to match the base's discovery namespace)

### Team-scoped permissions + Filament tenancy
- `App\Models\Permission`/`Role`; `config/permission.php` → App models, `teams => true`
- `User`: `HasRoles` + `FilamentUser`/`HasTenants`/`HasDefaultTenant` + `latestTeam()`
- Resolved the `HasRoles::teams` vs `HasTeams::teams` trait collision by **keeping Jetstream's** and excluding Spatie's (Spatie scopes via the `team_id` column) — cleaner than `main`, which dropped `HasTeams` entirely
- `AdminPanelProvider`: `->tenant(Team)`, `FilamentShieldPlugin->scopeToTenant(Utils::isTenancyEnabled())` (the 500-guard), `tenantMiddleware([SyncShieldTenant])`. Redundant `TeamsPermission` middleware intentionally **not** ported.
- `TeamPolicy` (auto-discovered)
- Filled a Phase 0 gap: `App\Models\Membership` + `TeamInvitation` (Jetstream defaults to `App\Models\*`; the installer never published them)

### Verification
- phpstan **level 9** clean · pint clean · **pest 28 passed / 0 failed / 12 skipped**
- A parallel adversarial review workflow proved the tenant panel renders Shield's `RoleResource` **without a 500** (the team-tenancy gotcha) — now a permanent regression test
- Review fixes folded in: `getTenants()` returns owned+member teams (members were lockable out), real render test, negative policy coverage

### ⚠️ Known / deferred
- `User::canAccessPanel()` returns `true` — **any authenticated user can reach `/admin`** (per-resource Shield policies still gate each resource). Tighten to a role check in a later auth-hardening phase.
- `AppPanelProvider` is intentionally **not** tenant-scoped this phase.
