### PR TITLE
Phase 2: theme system (ThemeManager + switcher + default/dark themes)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,9 @@ Spatie Permission roles/permissions are team-scoped (`config/permission.php` `te
 - **Known:** `User::canAccessPanel()` returns `true` (any authenticated user reaches `/admin`); per-resource Shield policies still gate each resource. Tighten to a role check in a later auth-hardening phase.
 
 ### Theme System
-Themes live under `themes/{name}/` with their own CSS/JS/views. The active theme is resolved by `ThemeManager` (`app/Services/ThemeManager.php`) and set per user via `theme_preference` on the users table. Blade directives and helpers are registered in `ThemeServiceProvider`. Vite is configured to build per-theme assets (currently commented out pending re-enablement via `glob`).
+Themes live under `themes/{name}/` (each with `theme.json` + `css/`/`js/`/`views/`), discovered from disk by `ThemeManager` (`app/Services/ThemeManager.php`). Active theme resolves user `theme_preference` → session → `config('theme.default')`; the `ThemeSwitcher` Livewire component + `set_theme()` helper persist it. `ThemeServiceProvider` registers the `theme` singleton/alias, 4 Blade directives (`@themeAsset`, `@themeCss`, `@themeJs`, `@themeLayout`), and shares `$activeTheme`/`$themeConfig` with all views. Theme view overrides work via `View` finder `prependLocation` (a `layouts.app` reference resolves to the active theme's override).
+
+**Per-theme Vite inputs are deferred** — `vite.config.js` builds only the main `app.css`/`app.js`. `@themeCss`/`@themeJs` gate on the Vite *manifest* (`ThemeManager::viteHasAsset`), so they emit nothing until `themes/*/{css,js}` are added to the Vite `input` and built — no 500. Wire those inputs in the PR that first ships a page extending a theme layout.
 
 ### Multi-Language
 User locale is stored in `users.locale`. The `SetLocale` middleware applies it on every request. `TranslationService` provides programmatic translation. Language files are in `lang/{locale}/`. A `LanguageSwitcher` Livewire component handles runtime switching.

--- a/app/Helpers/theme_helpers.php
+++ b/app/Helpers/theme_helpers.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Models\User;
+use App\Services\ThemeManager;
+
+if (! function_exists('theme')) {
+    /**
+     * Get the ThemeManager instance.
+     */
+    function theme(): ThemeManager
+    {
+        return app(ThemeManager::class);
+    }
+}
+
+if (! function_exists('active_theme')) {
+    /**
+     * Get the active theme name.
+     */
+    function active_theme(): string
+    {
+        return theme()->getActiveTheme();
+    }
+}
+
+if (! function_exists('theme_asset')) {
+    /**
+     * Generate a URL for a theme asset.
+     */
+    function theme_asset(string $path, ?string $theme = null): string
+    {
+        $theme = $theme ?? active_theme();
+
+        return asset("themes/{$theme}/{$path}");
+    }
+}
+
+if (! function_exists('theme_path')) {
+    /**
+     * Get the full path to a theme directory.
+     */
+    function theme_path(?string $theme = null): string
+    {
+        return theme()->getThemePath($theme);
+    }
+}
+
+if (! function_exists('theme_views_path')) {
+    /**
+     * Get the full path to a theme's views directory.
+     */
+    function theme_views_path(?string $theme = null): string
+    {
+        return theme()->getThemeViewsPath($theme);
+    }
+}
+
+if (! function_exists('set_theme')) {
+    /**
+     * Set the active theme, persisting to session and the authenticated user.
+     */
+    function set_theme(string $themeName): void
+    {
+        theme()->setTheme($themeName);
+
+        session(['theme_preference' => $themeName]);
+
+        if (($user = auth()->user()) instanceof User) {
+            $user->update(['theme_preference' => $themeName]);
+        }
+    }
+}
+
+if (! function_exists('theme_layout')) {
+    /**
+     * Get the theme-specific layout or fall back to default.
+     */
+    function theme_layout(string $layout): string
+    {
+        return theme()->getLayout($layout);
+    }
+}

--- a/app/Livewire/ThemeSwitcher.php
+++ b/app/Livewire/ThemeSwitcher.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Services\ThemeManager;
+use Illuminate\View\View;
+use Livewire\Component;
+
+class ThemeSwitcher extends Component
+{
+    public ?string $currentTheme = null;
+
+    /** @var array<string, array<string, mixed>> */
+    public array $availableThemes = [];
+
+    public function mount(): void
+    {
+        $themeManager = app(ThemeManager::class);
+        $this->currentTheme = $themeManager->getActiveTheme();
+        $this->availableThemes = $themeManager->getThemes();
+    }
+
+    public function switchTheme(string $theme): void
+    {
+        $themeManager = app(ThemeManager::class);
+
+        if (! $themeManager->themeExists($theme)) {
+            return;
+        }
+
+        set_theme($theme);
+        $this->currentTheme = $theme;
+        $this->dispatch('theme-changed', theme: $theme);
+        session()->flash('message', 'Theme changed successfully!');
+
+        $referer = request()->header('Referer');
+        $this->redirect(is_string($referer) ? $referer : '/');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.theme-switcher');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -22,6 +22,9 @@ use Laravel\Jetstream\HasTeams;
 use Laravel\Sanctum\HasApiTokens;
 use Spatie\Permission\Traits\HasRoles;
 
+/**
+ * @property string|null $theme_preference
+ */
 class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasTenants
 {
     use HasApiTokens;
@@ -52,6 +55,7 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         'name',
         'email',
         'password',
+        'theme_preference',
     ];
 
     /**

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -63,9 +63,13 @@ class ThemeServiceProvider extends ServiceProvider
     {
         Blade::directive('themeAsset', fn (string $expression): string => "<?php echo asset('themes/' . app('theme')->getActiveTheme() . '/' . {$expression}); ?>");
 
-        Blade::directive('themeCss', fn (): string => "<?php \$theme = app('theme')->getActiveTheme(); if (app('theme')->getThemeCss()) { echo app(\Illuminate\Foundation\Vite::class)('themes/' . \$theme . '/css/app.css'); } ?>");
+        // ponytail: @themeCss/@themeJs gate on the Vite MANIFEST, not disk — per-theme
+        // Vite inputs are deferred, so until themes/*/{css,js} are added to vite.config.js
+        // input + built, these emit nothing rather than throwing "Unable to locate file
+        // in Vite manifest". They light up automatically once the assets are built.
+        Blade::directive('themeCss', fn (): string => "<?php \$__p = 'themes/' . app('theme')->getActiveTheme() . '/css/app.css'; if (app('theme')->viteHasAsset(\$__p)) { echo app(\Illuminate\Foundation\Vite::class)(\$__p); } ?>");
 
-        Blade::directive('themeJs', fn (): string => "<?php \$theme = app('theme')->getActiveTheme(); if (app('theme')->getThemeJs()) { echo app(\Illuminate\Foundation\Vite::class)('themes/' . \$theme . '/js/app.js'); } ?>");
+        Blade::directive('themeJs', fn (): string => "<?php \$__p = 'themes/' . app('theme')->getActiveTheme() . '/js/app.js'; if (app('theme')->viteHasAsset(\$__p)) { echo app(\Illuminate\Foundation\Vite::class)(\$__p); } ?>");
 
         Blade::directive('themeLayout', fn (string $expression): string => "<?php echo app('theme')->getLayout({$expression}); ?>");
     }

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\User;
+use App\Services\ThemeManager;
+use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\View\View as ViewContract;
+
+class ThemeServiceProvider extends ServiceProvider
+{
+    /**
+     * Register services.
+     */
+    public function register(): void
+    {
+        $this->app->singleton(ThemeManager::class, fn () => new ThemeManager());
+        $this->app->alias(ThemeManager::class, 'theme');
+    }
+
+    /**
+     * Bootstrap services.
+     */
+    public function boot(): void
+    {
+        $themeManager = $this->app->make(ThemeManager::class);
+        $themeManager->setTheme($this->determineActiveTheme());
+
+        $this->registerBladeDirectives();
+
+        View::composer('*', function (ViewContract $view) use ($themeManager): void {
+            $view->with('activeTheme', $themeManager->getActiveTheme());
+            $view->with('themeConfig', $themeManager->getThemeConfig());
+        });
+    }
+
+    /**
+     * Determine the active theme: authenticated user preference → session → config default.
+     */
+    protected function determineActiveTheme(): string
+    {
+        $user = auth()->user();
+        if ($user instanceof User && is_string($user->theme_preference) && $user->theme_preference !== '') {
+            return $user->theme_preference;
+        }
+
+        $session = session('theme_preference');
+        if (is_string($session) && $session !== '') {
+            return $session;
+        }
+
+        $default = config('theme.default', 'default');
+
+        return is_string($default) ? $default : 'default';
+    }
+
+    /**
+     * Register custom Blade directives for themes.
+     */
+    protected function registerBladeDirectives(): void
+    {
+        Blade::directive('themeAsset', fn (string $expression): string => "<?php echo asset('themes/' . app('theme')->getActiveTheme() . '/' . {$expression}); ?>");
+
+        Blade::directive('themeCss', fn (): string => "<?php \$theme = app('theme')->getActiveTheme(); if (app('theme')->getThemeCss()) { echo app(\Illuminate\Foundation\Vite::class)('themes/' . \$theme . '/css/app.css'); } ?>");
+
+        Blade::directive('themeJs', fn (): string => "<?php \$theme = app('theme')->getActiveTheme(); if (app('theme')->getThemeJs()) { echo app(\Illuminate\Foundation\Vite::class)('themes/' . \$theme . '/js/app.js'); } ?>");
+
+        Blade::directive('themeLayout', fn (string $expression): string => "<?php echo app('theme')->getLayout({$expression}); ?>");
+    }
+}

--- a/app/Services/ThemeManager.php
+++ b/app/Services/ThemeManager.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+use Illuminate\View\FileViewFinder;
+
+class ThemeManager
+{
+    protected string $activeTheme;
+
+    /** @var array<string, array<string, mixed>> */
+    protected array $themes = [];
+
+    protected readonly string $themesPath;
+
+    public function __construct()
+    {
+        $this->themesPath = base_path('themes');
+        $default = config('theme.default', 'default');
+        $this->activeTheme = is_string($default) ? $default : 'default';
+        $this->loadThemes();
+    }
+
+    /**
+     * Load all available themes.
+     */
+    protected function loadThemes(): void
+    {
+        if (! File::exists($this->themesPath)) {
+            File::makeDirectory($this->themesPath, 0755, true);
+        }
+
+        $themeDirs = File::directories($this->themesPath);
+
+        foreach ($themeDirs as $themeDir) {
+            $themeName = basename($themeDir);
+            $themeConfigPath = $themeDir.'/theme.json';
+
+            $decoded = File::exists($themeConfigPath)
+                ? json_decode(File::get($themeConfigPath), true)
+                : null;
+
+            $this->themes[$themeName] = is_array($decoded) ? $decoded : [
+                'name' => $themeName,
+                'label' => ucfirst($themeName),
+                'description' => "Custom theme: {$themeName}",
+            ];
+        }
+    }
+
+    /**
+     * Set the active theme.
+     */
+    public function setTheme(string $theme): void
+    {
+        if ($this->themeExists($theme)) {
+            $this->activeTheme = $theme;
+            $this->registerThemePaths();
+        }
+    }
+
+    /**
+     * Get the active theme.
+     */
+    public function getActiveTheme(): string
+    {
+        return $this->activeTheme;
+    }
+
+    /**
+     * Get all available themes.
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function getThemes(): array
+    {
+        return $this->themes;
+    }
+
+    /**
+     * Check if a theme exists.
+     */
+    public function themeExists(string $theme): bool
+    {
+        return isset($this->themes[$theme]);
+    }
+
+    /**
+     * Get theme path.
+     */
+    public function getThemePath(?string $theme = null): string
+    {
+        $theme = $theme ?? $this->activeTheme;
+
+        return $this->themesPath.'/'.$theme;
+    }
+
+    /**
+     * Get theme views path.
+     */
+    public function getThemeViewsPath(?string $theme = null): string
+    {
+        $theme = $theme ?? $this->activeTheme;
+
+        return $this->themesPath.'/'.$theme.'/views';
+    }
+
+    /**
+     * Get theme asset path (CSS/JS).
+     */
+    public function getThemeAssetPath(string $type, ?string $theme = null): ?string
+    {
+        $theme = $theme ?? $this->activeTheme;
+        $assetPath = $this->themesPath.'/'.$theme.'/'.$type;
+
+        if (File::exists($assetPath)) {
+            return $assetPath;
+        }
+
+        return null;
+    }
+
+    /**
+     * Register theme view paths with Laravel's view finder.
+     */
+    public function registerThemePaths(): void
+    {
+        $themeViewsPath = $this->getThemeViewsPath();
+        $finder = View::getFinder();
+
+        if (File::exists($themeViewsPath) && $finder instanceof FileViewFinder) {
+            // Add theme views path before the default views path
+            $finder->prependLocation($themeViewsPath);
+        }
+    }
+
+    /**
+     * Get theme CSS file path for Vite.
+     */
+    public function getThemeCss(?string $theme = null): ?string
+    {
+        $theme = $theme ?? $this->activeTheme;
+        $cssPath = "themes/{$theme}/css/app.css";
+
+        if (File::exists(base_path($cssPath))) {
+            return $cssPath;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get theme JS file path for Vite.
+     */
+    public function getThemeJs(?string $theme = null): ?string
+    {
+        $theme = $theme ?? $this->activeTheme;
+        $jsPath = "themes/{$theme}/js/app.js";
+
+        if (File::exists(base_path($jsPath))) {
+            return $jsPath;
+        }
+
+        return null;
+    }
+
+    /**
+     * Get theme configuration.
+     *
+     * @return array<string, mixed>
+     */
+    public function getThemeConfig(?string $theme = null): array
+    {
+        $theme = $theme ?? $this->activeTheme;
+
+        return $this->themes[$theme] ?? [];
+    }
+
+    /**
+     * Clear theme cache.
+     */
+    public function clearCache(): void
+    {
+        Cache::forget('themes.active');
+        Cache::forget('themes.list');
+    }
+
+    /**
+     * Check if theme has custom layout.
+     */
+    public function hasCustomLayout(string $layout, ?string $theme = null): bool
+    {
+        $theme = $theme ?? $this->activeTheme;
+        $layoutPath = $this->getThemeViewsPath($theme)."/layouts/{$layout}.blade.php";
+
+        return File::exists($layoutPath);
+    }
+
+    /**
+     * Get the theme layout path. Theme view paths are registered with the view
+     * finder, so the same "layouts.{name}" reference resolves to the theme's
+     * override when present and the default otherwise.
+     */
+    public function getLayout(string $layout, ?string $theme = null): string
+    {
+        return "layouts.{$layout}";
+    }
+}

--- a/app/Services/ThemeManager.php
+++ b/app/Services/ThemeManager.php
@@ -168,6 +168,24 @@ class ThemeManager
     }
 
     /**
+     * Whether the given path is present in the built Vite manifest. Used to gate
+     * the @themeCss/@themeJs directives: a theme asset on disk but not yet added to
+     * the Vite build would otherwise throw "Unable to locate file in Vite manifest".
+     */
+    public function viteHasAsset(string $path): bool
+    {
+        $manifest = public_path('build/manifest.json');
+
+        if (! File::exists($manifest)) {
+            return false;
+        }
+
+        $decoded = json_decode(File::get($manifest), true);
+
+        return is_array($decoded) && array_key_exists($path, $decoded);
+    }
+
+    /**
      * Get theme configuration.
      *
      * @return array<string, mixed>

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -7,6 +7,7 @@ use App\Providers\FortifyServiceProvider;
 use App\Providers\HorizonServiceProvider;
 use App\Providers\SocialstreamServiceProvider;
 use App\Providers\TelescopeServiceProvider;
+use App\Providers\ThemeServiceProvider;
 
 return [
     AppServiceProvider::class,
@@ -16,4 +17,5 @@ return [
     HorizonServiceProvider::class,
     SocialstreamServiceProvider::class,
     TelescopeServiceProvider::class,
+    ThemeServiceProvider::class,
 ];

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Helpers/theme_helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/config/theme.php
+++ b/config/theme.php
@@ -1,0 +1,18 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Theme
+    |--------------------------------------------------------------------------
+    |
+    | The theme used when a user has no stored preference. Themes themselves are
+    | discovered from the `themes/` directory (each with a theme.json), so this
+    | is the only value the application reads.
+    |
+    */
+
+    'default' => env('THEME_DEFAULT', 'default'),
+
+];

--- a/database/migrations/2026_02_16_215049_add_theme_preference_to_users_table.php
+++ b/database/migrations/2026_02_16_215049_add_theme_preference_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('theme_preference')->nullable()->default('default')->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('theme_preference');
+        });
+    }
+};

--- a/resources/views/livewire/theme-switcher.blade.php
+++ b/resources/views/livewire/theme-switcher.blade.php
@@ -1,0 +1,68 @@
+<div class="theme-switcher">
+    @if (session()->has('message'))
+        <div class="alert alert-success mb-2 text-green-600">
+            {{ session('message') }}
+        </div>
+    @endif
+    
+    <div class="relative inline-block text-left">
+        <div>
+            <button type="button" 
+                    class="inline-flex justify-center w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none"
+                    id="theme-menu-button" 
+                    aria-expanded="true" 
+                    aria-haspopup="true"
+                    onclick="document.getElementById('theme-menu').classList.toggle('hidden')">
+                <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01"/>
+                </svg>
+                Theme: {{ ucfirst($currentTheme) }}
+                <svg class="-mr-1 ml-2 h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd"/>
+                </svg>
+            </button>
+        </div>
+
+        <div class="hidden origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 divide-y divide-gray-100 dark:divide-gray-700 focus:outline-none z-50" 
+             id="theme-menu" 
+             role="menu" 
+             aria-orientation="vertical" 
+             aria-labelledby="theme-menu-button">
+            <div class="py-1" role="none">
+                @foreach($availableThemes as $themeKey => $themeData)
+                    <button wire:click="switchTheme('{{ $themeKey }}')" 
+                            class="w-full text-left px-4 py-2 text-sm {{ $currentTheme === $themeKey ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white font-semibold' : 'text-gray-700 dark:text-gray-200' }} hover:bg-gray-100 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white"
+                            role="menuitem">
+                        <div class="flex items-center">
+                            @if($currentTheme === $themeKey)
+                                <svg class="w-4 h-4 mr-2 text-green-500" fill="currentColor" viewBox="0 0 20 20">
+                                    <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd"/>
+                                </svg>
+                            @else
+                                <span class="w-4 h-4 mr-2"></span>
+                            @endif
+                            <div>
+                                <div class="font-medium">{{ $themeData['label'] ?? ucfirst($themeKey) }}</div>
+                                @if(isset($themeData['description']))
+                                    <div class="text-xs text-gray-500 dark:text-gray-400">{{ $themeData['description'] }}</div>
+                                @endif
+                            </div>
+                        </div>
+                    </button>
+                @endforeach
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+    // Close dropdown when clicking outside
+    document.addEventListener('click', function(event) {
+        const menu = document.getElementById('theme-menu');
+        const button = document.getElementById('theme-menu-button');
+        
+        if (menu && button && !menu.contains(event.target) && !button.contains(event.target)) {
+            menu.classList.add('hidden');
+        }
+    });
+</script>

--- a/tests/Feature/ThemeServiceProviderTest.php
+++ b/tests/Feature/ThemeServiceProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Models\User;
+use App\Services\ThemeManager;
+use Illuminate\Support\Facades\Blade;
+
+it('binds the ThemeManager singleton and the theme alias to one instance', function () {
+    expect(app(ThemeManager::class))->toBeInstanceOf(ThemeManager::class)
+        ->and(app('theme'))->toBe(app(ThemeManager::class));
+});
+
+it('registers the theme blade directives', function () {
+    expect(Blade::getCustomDirectives())
+        ->toHaveKeys(['themeAsset', 'themeCss', 'themeJs', 'themeLayout']);
+});
+
+it('renders the themeAsset directive against the active theme', function () {
+    expect(Blade::render("@themeAsset('css/app.css')"))
+        ->toContain('themes/'.active_theme().'/css/app.css');
+});
+
+it('persists set_theme to session and the authenticated user', function () {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    set_theme('dark');
+
+    expect(session('theme_preference'))->toBe('dark')
+        ->and($user->fresh()->theme_preference)->toBe('dark');
+});
+
+it('set_theme without auth writes session only and does not throw', function () {
+    set_theme('dark');
+
+    expect(session('theme_preference'))->toBe('dark');
+});

--- a/tests/Feature/ThemeServiceProviderTest.php
+++ b/tests/Feature/ThemeServiceProviderTest.php
@@ -3,6 +3,7 @@
 use App\Models\User;
 use App\Services\ThemeManager;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\View;
 
 it('binds the ThemeManager singleton and the theme alias to one instance', function () {
     expect(app(ThemeManager::class))->toBeInstanceOf(ThemeManager::class)
@@ -17,6 +18,24 @@ it('registers the theme blade directives', function () {
 it('renders the themeAsset directive against the active theme', function () {
     expect(Blade::render("@themeAsset('css/app.css')"))
         ->toContain('themes/'.active_theme().'/css/app.css');
+});
+
+it('resolves a shared view name to the active theme override and follows switches', function () {
+    app(ThemeManager::class)->setTheme('dark');
+    expect(View::getFinder()->find('layouts.app'))
+        ->toContain('themes/dark/views/layouts/app.blade.php');
+
+    View::getFinder()->flush();
+
+    app(ThemeManager::class)->setTheme('default');
+    expect(View::getFinder()->find('layouts.app'))
+        ->toContain('themes/default/views/layouts/app.blade.php');
+});
+
+it('does not throw rendering themeCss/themeJs when the theme asset is not in the Vite manifest', function () {
+    app(ThemeManager::class)->setTheme('dark');
+
+    expect(Blade::render('@themeCss @themeJs'))->toBeString();
 });
 
 it('persists set_theme to session and the authenticated user', function () {

--- a/tests/Feature/ThemeSwitcherTest.php
+++ b/tests/Feature/ThemeSwitcherTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Livewire\ThemeSwitcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('theme switcher renders with default theme', function () {
+    Livewire::test(ThemeSwitcher::class)
+        ->assertSet('currentTheme', 'default');
+});
+
+test('theme switcher can switch to dark theme', function () {
+    Livewire::test(ThemeSwitcher::class)
+        ->call('switchTheme', 'dark')
+        ->assertSet('currentTheme', 'dark');
+});
+
+test('theme switcher ignores unknown themes', function () {
+    Livewire::test(ThemeSwitcher::class)
+        ->call('switchTheme', 'nonexistent')
+        ->assertSet('currentTheme', 'default');
+});
+
+test('theme switcher loads available themes on mount', function () {
+    Livewire::test(ThemeSwitcher::class)
+        ->assertSet('availableThemes', function ($themes) {
+            return is_array($themes) && count($themes) > 0;
+        });
+});

--- a/tests/Unit/ThemeManagerTest.php
+++ b/tests/Unit/ThemeManagerTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use App\Services\ThemeManager;
+use Illuminate\Support\Facades\File;
+
+beforeEach(function () {
+    $this->themeManager = new ThemeManager();
+});
+
+test('theme manager loads themes from themes directory', function () {
+    $themes = $this->themeManager->getThemes();
+
+    expect($themes)->toBeArray()
+        ->and($themes)->not->toBeEmpty();
+});
+
+test('default theme exists', function () {
+    expect($this->themeManager->themeExists('default'))->toBeTrue();
+});
+
+test('dark theme exists', function () {
+    expect($this->themeManager->themeExists('dark'))->toBeTrue();
+});
+
+test('can get active theme', function () {
+    $activeTheme = $this->themeManager->getActiveTheme();
+
+    expect($activeTheme)->toBeString()
+        ->and($activeTheme)->toBe('default');
+});
+
+test('can set theme', function () {
+    $this->themeManager->setTheme('dark');
+
+    expect($this->themeManager->getActiveTheme())->toBe('dark');
+});
+
+test('cannot set non-existent theme', function () {
+    $initialTheme = $this->themeManager->getActiveTheme();
+    $this->themeManager->setTheme('nonexistent');
+
+    expect($this->themeManager->getActiveTheme())->toBe($initialTheme);
+});
+
+test('can get theme path', function () {
+    $themePath = $this->themeManager->getThemePath('default');
+
+    expect($themePath)->toContain('themes/default')
+        ->and(File::exists($themePath))->toBeTrue();
+});
+
+test('can get theme views path', function () {
+    $themeViewsPath = $this->themeManager->getThemeViewsPath('default');
+
+    expect($themeViewsPath)->toContain('themes/default/views')
+        ->and(File::exists($themeViewsPath))->toBeTrue();
+});
+
+test('can get theme configuration', function () {
+    $config = $this->themeManager->getThemeConfig('default');
+
+    expect($config)->toBeArray()
+        ->and($config)->toHaveKey('name')
+        ->and($config)->toHaveKey('label')
+        ->and($config['name'])->toBe('default');
+});
+
+test('theme has CSS file', function () {
+    $cssPath = $this->themeManager->getThemeCss('default');
+
+    expect($cssPath)->not->toBeNull()
+        ->and($cssPath)->toContain('themes/default/css/app.css')
+        ->and(File::exists(base_path($cssPath)))->toBeTrue();
+});
+
+test('theme has JS file', function () {
+    $jsPath = $this->themeManager->getThemeJs('default');
+
+    expect($jsPath)->not->toBeNull()
+        ->and($jsPath)->toContain('themes/default/js/app.js')
+        ->and(File::exists(base_path($jsPath)))->toBeTrue();
+});
+
+test('theme has custom layout', function () {
+    $hasLayout = $this->themeManager->hasCustomLayout('app', 'default');
+
+    expect($hasLayout)->toBeTrue();
+});
+
+test('can get layout path', function () {
+    $layoutPath = $this->themeManager->getLayout('app', 'default');
+
+    expect($layoutPath)->toBeString()
+        ->and($layoutPath)->toContain('layouts.app');
+});
+
+test('theme helper functions work', function () {
+    expect(function_exists('theme'))->toBeTrue()
+        ->and(function_exists('active_theme'))->toBeTrue()
+        ->and(function_exists('theme_asset'))->toBeTrue()
+        ->and(function_exists('theme_path'))->toBeTrue()
+        ->and(function_exists('theme_views_path'))->toBeTrue()
+        ->and(function_exists('set_theme'))->toBeTrue()
+        ->and(function_exists('theme_layout'))->toBeTrue();
+});
+
+test('active_theme helper returns string', function () {
+    $theme = active_theme();
+
+    expect($theme)->toBeString();
+});
+
+test('theme_asset helper generates URL', function () {
+    $url = theme_asset('images/logo.png');
+
+    expect($url)->toBeString()
+        ->and($url)->toContain('themes/')
+        ->and($url)->toContain('images/logo.png');
+});
+
+test('theme_path helper returns path', function () {
+    $path = theme_path('default');
+
+    expect($path)->toBeString()
+        ->and($path)->toContain('themes/default');
+});
+
+test('theme_views_path helper returns views path', function () {
+    $path = theme_views_path('default');
+
+    expect($path)->toBeString()
+        ->and($path)->toContain('themes/default/views');
+});
+
+test('dark theme has correct configuration', function () {
+    $config = $this->themeManager->getThemeConfig('dark');
+
+    expect($config)->toBeArray()
+        ->and($config['name'])->toBe('dark')
+        ->and($config['label'])->toBe('Dark Theme')
+        ->and($config)->toHaveKey('colors')
+        ->and($config['colors']['primary'])->toBe('indigo');
+});
+
+test('default theme has correct configuration', function () {
+    $config = $this->themeManager->getThemeConfig('default');
+
+    expect($config)->toBeArray()
+        ->and($config['name'])->toBe('default')
+        ->and($config['label'])->toBe('Default Theme')
+        ->and($config)->toHaveKey('colors')
+        ->and($config['colors']['primary'])->toBe('gray');
+});

--- a/themes/dark/css/app.css
+++ b/themes/dark/css/app.css
@@ -1,0 +1,23 @@
+@import 'tailwindcss';
+
+/* Dark Theme Custom Styles */
+:root {
+    --theme-primary: theme('colors.indigo.600');
+    --theme-secondary: theme('colors.purple.600');
+}
+
+@layer base {
+    body {
+        @apply bg-gray-900 text-gray-100;
+    }
+}
+
+@layer components {
+    .theme-btn-primary {
+        @apply bg-indigo-600 hover:bg-indigo-700 text-white font-semibold py-2 px-4 rounded shadow-lg;
+    }
+    
+    .theme-card {
+        @apply bg-gray-800 border-gray-700 text-gray-100;
+    }
+}

--- a/themes/dark/js/app.js
+++ b/themes/dark/js/app.js
@@ -1,0 +1,11 @@
+// Dark Theme JavaScript
+console.log('Dark theme loaded');
+
+// Force dark mode
+document.documentElement.classList.add('dark');
+
+// Theme-specific functionality
+document.addEventListener('DOMContentLoaded', function() {
+    // Initialize dark theme features
+    console.log('Dark theme initialized');
+});

--- a/themes/dark/theme.json
+++ b/themes/dark/theme.json
@@ -1,0 +1,11 @@
+{
+    "name": "dark",
+    "label": "Dark Theme",
+    "description": "A dark color scheme for the application",
+    "version": "1.0.0",
+    "author": "Liberu Software",
+    "colors": {
+        "primary": "indigo",
+        "secondary": "purple"
+    }
+}

--- a/themes/dark/views/layouts/app.blade.php
+++ b/themes/dark/views/layouts/app.blade.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title>{{ config('app.name', 'Laravel') }} - Dark Theme</title>
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        <!-- Scripts -->
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @themeCss
+        @themeJs
+        
+        @livewireStyles
+    </head>
+    <body class="font-sans antialiased dark">
+        <div class="min-h-screen bg-gray-900">
+            @yield('content')
+        </div>
+
+        @livewireScripts
+    </body>
+</html>

--- a/themes/default/css/app.css
+++ b/themes/default/css/app.css
@@ -1,0 +1,19 @@
+@import 'tailwindcss';
+
+/* Default Theme Custom Styles */
+:root {
+    --theme-primary: theme('colors.gray.600');
+    --theme-secondary: theme('colors.slate.600');
+}
+
+@layer base {
+    body {
+        @apply bg-gray-50 dark:bg-gray-900;
+    }
+}
+
+@layer components {
+    .theme-btn-primary {
+        @apply bg-gray-600 hover:bg-gray-700 text-white font-semibold py-2 px-4 rounded;
+    }
+}

--- a/themes/default/js/app.js
+++ b/themes/default/js/app.js
@@ -1,0 +1,7 @@
+// Default Theme JavaScript
+console.log('Default theme loaded');
+
+// Theme-specific functionality can be added here
+document.addEventListener('DOMContentLoaded', function() {
+    // Initialize theme-specific features
+});

--- a/themes/default/theme.json
+++ b/themes/default/theme.json
@@ -1,0 +1,11 @@
+{
+    "name": "default",
+    "label": "Default Theme",
+    "description": "The default application theme",
+    "version": "1.0.0",
+    "author": "Liberu Software",
+    "colors": {
+        "primary": "gray",
+        "secondary": "slate"
+    }
+}

--- a/themes/default/views/layouts/app.blade.php
+++ b/themes/default/views/layouts/app.blade.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
+
+        <title>{{ config('app.name', 'Laravel') }}</title>
+
+        <!-- Fonts -->
+        <link rel="preconnect" href="https://fonts.bunny.net">
+        <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
+
+        <!-- Scripts -->
+        @vite(['resources/css/app.css', 'resources/js/app.js'])
+        @themeCss
+        @themeJs
+        
+        @livewireStyles
+    </head>
+    <body class="font-sans antialiased">
+        <div class="min-h-screen bg-gray-100 dark:bg-gray-900">
+            @yield('content')
+        </div>
+
+        @livewireScripts
+    </body>
+</html>


### PR DESCRIPTION
## Phase 2 — Theme system

Stacks on #575 (Phase 1). Base `phase-1-settings-tenancy`; rebase down the stack as earlier PRs merge.

Ported from `feat/edit-profile-clear-signal` onto the clean base (the source is the only branch that has the theme system; `main` is lean), TDD throughout.

### Included
- `ThemeManager` — discovers themes from `themes/*/theme.json`; resolves active theme (user `theme_preference` → session → `config('theme.default')`)
- `ThemeServiceProvider` — `theme` singleton/alias, 4 Blade directives (`@themeAsset`/`@themeCss`/`@themeJs`/`@themeLayout`), shares `$activeTheme`/`$themeConfig` with all views; theme view overrides via finder `prependLocation`
- `theme_helpers.php` (7 global fns, autoloaded via composer `files`)
- `ThemeSwitcher` Livewire component + view; `themes/{default,dark}/`
- `User.theme_preference` (fillable + `@property`) + migration

### Fixes / decisions
- **Persistence never worked on source** (`theme_preference` was absent from `$fillable`) — fixed + covered by a `fresh()` assertion
- **`@themeCss`/`@themeJs` gate on the Vite manifest, not disk** — per-theme Vite inputs are deferred (nothing renders a theme layout yet), so the directives emit nothing until the assets are built instead of throwing `Unable to locate file in Vite manifest`
- Trimmed dead `config/theme.php`; did **not** port the demo page/route, `THEME_*.md`, or `locale_helpers`
- PHPStan level-9 hardening: typed arrays, `is_string` guards on `config()`/`session()` mixed, `instanceof User`/`FileViewFinder` narrowing, typed Livewire props + `void switchTheme` via `$this->redirect()`

### Verification
- phpstan **L9** clean · pint clean · **pest 59 passed / 0 failed**
- Adversarial review workflow confirmed: theme view override works at runtime, switcher persists end-to-end, and the manifest gate prevents the `@themeCss` 500. Findings folded in (manifest gate, override regression test, docs).

### Deferred
- Per-theme Vite `input` globs — add in the PR that first ships a page extending a theme layout.
