### PR TITLE
Phase 3: multi-language (TranslationService + SetLocale + LanguageSwitcher)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,8 +105,8 @@ Themes live under `themes/{name}/` (each with `theme.json` + `css/`/`js/`/`views
 
 **Per-theme Vite inputs are deferred** — `vite.config.js` builds only the main `app.css`/`app.js`. `@themeCss`/`@themeJs` gate on the Vite *manifest* (`ThemeManager::viteHasAsset`), so they emit nothing until `themes/*/{css,js}` are added to the Vite `input` and built — no 500. Wire those inputs in the PR that first ships a page extending a theme layout.
 
-### Multi-Language
-User locale is stored in `users.locale`. The `SetLocale` middleware applies it on every request. `TranslationService` provides programmatic translation. Language files are in `lang/{locale}/`. A `LanguageSwitcher` Livewire component handles runtime switching.
+### Multi-Language (Phase 3 — done)
+Supported locales live in `config('app.supported_locales')` (en/es/fr/de). `SetLocale` resolves locale (request param → session → `users.locale` → `Accept-Language` → default, validated against supported) and runs on the **`web` group** (`bootstrap/app.php`) **and both Filament panels** (added to each panel's `->middleware([])`, since Filament panels don't use the `web` group). Precedence is request > session > user (a stale session locale can shadow a freshly-logged-in user until logout flushes the session). `LanguageSwitcher` Livewire component persists to session + `users.locale`. `TranslationService` does on-demand translation via the MyMemory API (cached 30 days). No `locale_helpers`/`lang/*/messages` were ported (no callers); add `lang/` files only when something calls `__('...')`. The `LanguageSwitcher` component isn't mounted in any view yet — mount `<livewire:language-switcher />` where a switcher UI is wanted.
 
 ### Search
 `SearchService` (`app/Services/SearchService.php`) performs cross-entity full-text search over Users, Posts, and Groups. Dedicated API controllers under `app/Http/Controllers/Api/` serve search results. Search indexes are added via migration `2026_02_14_000003_add_search_indexes_to_users_table.php`.

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -21,10 +21,11 @@ class SetLocale
     public function handle(Request $request, Closure $next): Response
     {
         $locale = null;
+        $fromRequest = false;
 
         if ($request->has('locale')) {
             $locale = $request->string('locale')->value();
-            Session::put('locale', $locale);
+            $fromRequest = true;
         }
 
         if (! $locale) {
@@ -50,6 +51,11 @@ class SetLocale
 
         if (in_array($locale, $supportedLocales, true)) {
             App::setLocale($locale);
+
+            // Persist only a validated, request-supplied locale (avoid storing arbitrary input).
+            if ($fromRequest) {
+                Session::put('locale', $locale);
+            }
         }
 
         return $next($request);

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Session;
+use Symfony\Component\HttpFoundation\Response;
+
+class SetLocale
+{
+    /**
+     * Handle an incoming request.
+     *
+     * Priority: request param → session → authenticated user → browser → default.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $locale = null;
+
+        if ($request->has('locale')) {
+            $locale = $request->string('locale')->value();
+            Session::put('locale', $locale);
+        }
+
+        if (! $locale) {
+            $session = Session::get('locale');
+            $locale = is_string($session) ? $session : null;
+        }
+
+        $user = auth()->user();
+        if (! $locale && $user instanceof User && is_string($user->locale) && $user->locale !== '') {
+            $locale = $user->locale;
+        }
+
+        if (! $locale) {
+            $locale = $this->detectLocaleFromBrowser($request);
+        }
+
+        if (! $locale) {
+            $default = config('app.locale', 'en');
+            $locale = is_string($default) ? $default : 'en';
+        }
+
+        $supportedLocales = array_keys((array) config('app.supported_locales', ['en' => 'English']));
+
+        if (in_array($locale, $supportedLocales, true)) {
+            App::setLocale($locale);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Detect the best supported locale from the browser's Accept-Language header.
+     */
+    private function detectLocaleFromBrowser(Request $request): ?string
+    {
+        $acceptLanguage = $request->header('Accept-Language') ?? $request->server('HTTP_ACCEPT_LANGUAGE');
+
+        if (! is_string($acceptLanguage) || $acceptLanguage === '') {
+            return null;
+        }
+
+        $supportedLocales = array_keys((array) config('app.supported_locales', ['en' => 'English']));
+
+        preg_match_all('/([a-z]{1,8}(-[a-z]{1,8})?)\s*(;\s*q\s*=\s*(1|0\.[0-9]+))?/i', $acceptLanguage, $matches);
+
+        if (count($matches[1]) === 0) {
+            return null;
+        }
+
+        /** @var array<string, string|int> $languages */
+        $languages = array_combine($matches[1], $matches[4]);
+
+        foreach ($languages as $lang => $val) {
+            if ($val === '') {
+                $languages[$lang] = 1;
+            }
+        }
+
+        arsort($languages, SORT_NUMERIC);
+
+        foreach ($languages as $lang => $priority) {
+            $code = substr((string) $lang, 0, 2);
+
+            if (in_array($code, $supportedLocales, true)) {
+                return $code;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Livewire/LanguageSwitcher.php
+++ b/app/Livewire/LanguageSwitcher.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\User;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Session;
+use Illuminate\View\View;
+use Livewire\Component;
+
+class LanguageSwitcher extends Component
+{
+    public string $currentLocale = '';
+
+    /** @var array<string, string> */
+    public array $availableLocales = [];
+
+    public function mount(): void
+    {
+        $this->currentLocale = App::getLocale();
+
+        $supported = config('app.supported_locales', []);
+        $locales = [];
+
+        if (is_array($supported)) {
+            foreach ($supported as $code => $label) {
+                if (is_string($label)) {
+                    $locales[(string) $code] = $label;
+                }
+            }
+        }
+
+        $this->availableLocales = $locales;
+    }
+
+    public function switchLanguage(string $locale): void
+    {
+        if (! array_key_exists($locale, $this->availableLocales)) {
+            return;
+        }
+
+        Session::put('locale', $locale);
+
+        if (($user = auth()->user()) instanceof User) {
+            $user->update(['locale' => $locale]);
+        }
+
+        $this->currentLocale = $locale;
+
+        $referer = request()->header('Referer');
+        $this->redirect(is_string($referer) ? $referer : '/');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.language-switcher');
+    }
+}

--- a/app/Livewire/LanguageSwitcher.php
+++ b/app/Livewire/LanguageSwitcher.php
@@ -47,8 +47,10 @@ class LanguageSwitcher extends Component
 
         $this->currentLocale = $locale;
 
+        // Refresh the current page, but never trust the raw Referer (open-redirect).
         $referer = request()->header('Referer');
-        $this->redirect(is_string($referer) ? $referer : '/');
+        $base = url('/');
+        $this->redirect(is_string($referer) && str_starts_with($referer, $base) ? $referer : '/');
     }
 
     public function render(): View

--- a/app/Livewire/ThemeSwitcher.php
+++ b/app/Livewire/ThemeSwitcher.php
@@ -33,8 +33,10 @@ class ThemeSwitcher extends Component
         $this->dispatch('theme-changed', theme: $theme);
         session()->flash('message', 'Theme changed successfully!');
 
+        // Refresh the current page, but never trust the raw Referer (open-redirect).
         $referer = request()->header('Referer');
-        $this->redirect(is_string($referer) ? $referer : '/');
+        $base = url('/');
+        $this->redirect(is_string($referer) && str_starts_with($referer, $base) ? $referer : '/');
     }
 
     public function render(): View

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,7 @@ use Spatie\Permission\Traits\HasRoles;
 
 /**
  * @property string|null $theme_preference
+ * @property string|null $locale
  */
 class User extends Authenticatable implements FilamentUser, HasDefaultTenant, HasTenants
 {
@@ -56,6 +57,7 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         'email',
         'password',
         'theme_preference',
+        'locale',
     ];
 
     /**

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Http\Middleware\SetLocale;
 use App\Models\Team;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use BezhanSalleh\FilamentShield\Middleware\SyncShieldTenant;
@@ -59,6 +60,7 @@ class AdminPanelProvider extends PanelProvider
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
+                SetLocale::class,
             ])
             ->plugins([
                 // Roles are team-scoped only when Spatie teams are enabled; gating on

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers\Filament;
 
+use App\Http\Middleware\SetLocale;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -49,6 +50,7 @@ class AppPanelProvider extends PanelProvider
                 SubstituteBindings::class,
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
+                SetLocale::class,
             ])
             ->authMiddleware([
                 Authenticate::class,

--- a/app/Services/TranslationService.php
+++ b/app/Services/TranslationService.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Services;
+
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class TranslationService
+{
+    /**
+     * Supported languages with their codes.
+     *
+     * @var array<string, string>
+     */
+    public const SUPPORTED_LANGUAGES = [
+        'en' => 'English',
+        'es' => 'Spanish',
+        'fr' => 'French',
+        'de' => 'German',
+    ];
+
+    /**
+     * Translate text from source language to target language.
+     * Uses the MyMemory Translation API (free tier).
+     */
+    public function translate(string $text, string $targetLang, string $sourceLang = 'en'): string
+    {
+        if ($sourceLang === $targetLang) {
+            return $text;
+        }
+
+        $cacheKey = "translation:{$sourceLang}:{$targetLang}:".md5($text);
+
+        if (Cache::has($cacheKey)) {
+            $cached = Cache::get($cacheKey);
+
+            return is_string($cached) ? $cached : $text;
+        }
+
+        try {
+            $response = Http::get('https://api.mymemory.translated.net/get', [
+                'q' => $text,
+                'langpair' => "{$sourceLang}|{$targetLang}",
+            ]);
+
+            if ($response->successful()) {
+                $translated = data_get((array) $response->json(), 'responseData.translatedText');
+
+                if (is_string($translated) && $translated !== '') {
+                    Cache::put($cacheKey, $translated, now()->addDays(30));
+
+                    return $translated;
+                }
+            }
+        } catch (\Exception $e) {
+            Log::error('Translation failed', [
+                'text' => $text,
+                'source' => $sourceLang,
+                'target' => $targetLang,
+                'error' => $e->getMessage(),
+            ]);
+        }
+
+        return $text;
+    }
+
+    /**
+     * Translate an array of texts (recursively for nested arrays).
+     *
+     * @param  array<int|string, mixed>  $texts
+     * @return array<int|string, mixed>
+     */
+    public function translateBatch(array $texts, string $targetLang, string $sourceLang = 'en'): array
+    {
+        $translations = [];
+
+        foreach ($texts as $key => $text) {
+            if (is_array($text)) {
+                $translations[$key] = $this->translateBatch($text, $targetLang, $sourceLang);
+            } elseif (is_string($text)) {
+                $translations[$key] = $this->translate($text, $targetLang, $sourceLang);
+
+                // Respect API rate limits.
+                usleep(100000);
+            } else {
+                $translations[$key] = $text;
+            }
+        }
+
+        return $translations;
+    }
+
+    /**
+     * Get the list of supported languages.
+     *
+     * @return array<string, string>
+     */
+    public function getSupportedLanguages(): array
+    {
+        return self::SUPPORTED_LANGUAGES;
+    }
+
+    /**
+     * Check if a language is supported.
+     */
+    public function isLanguageSupported(string $langCode): bool
+    {
+        return array_key_exists($langCode, self::SUPPORTED_LANGUAGES);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SetLocale;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -13,7 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        $middleware->appendToGroup('web', [SetLocale::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(

--- a/config/app.php
+++ b/config/app.php
@@ -84,6 +84,13 @@ return [
 
     'faker_locale' => env('APP_FAKER_LOCALE', 'en_US'),
 
+    'supported_locales' => [
+        'en' => 'English',
+        'es' => 'Español',
+        'fr' => 'Français',
+        'de' => 'Deutsch',
+    ],
+
     /*
     |--------------------------------------------------------------------------
     | Encryption Key

--- a/database/migrations/2026_02_16_000001_add_locale_to_users_table.php
+++ b/database/migrations/2026_02_16_000001_add_locale_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('locale', 5)->default('en')->after('email');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('locale');
+        });
+    }
+};

--- a/resources/views/livewire/language-switcher.blade.php
+++ b/resources/views/livewire/language-switcher.blade.php
@@ -1,0 +1,45 @@
+<div class="relative inline-block text-left" x-data="{ open: false }">
+    <div>
+        <button type="button" @click="open = !open" 
+                class="inline-flex items-center justify-center w-full rounded-md border border-gray-300 dark:border-gray-600 shadow-sm px-4 py-2 bg-white dark:bg-gray-800 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                id="language-menu" aria-haspopup="true">
+            <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h12M9 3v2m1.048 9.5A18.022 18.022 0 016.412 9m6.088 9h7M11 21l5-10 5 10M12.751 5C11.783 10.77 8.07 15.61 3 18.129" />
+            </svg>
+            {{ $availableLocales[$currentLocale] ?? 'English' }}
+            <svg class="-mr-1 ml-2 h-5 w-5" fill="currentColor" viewBox="0 0 20 20">
+                <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
+            </svg>
+        </button>
+    </div>
+
+    <div x-show="open" 
+         @click.away="open = false"
+         x-transition:enter="transition ease-out duration-100"
+         x-transition:enter-start="transform opacity-0 scale-95"
+         x-transition:enter-end="transform opacity-100 scale-100"
+         x-transition:leave="transition ease-in duration-75"
+         x-transition:leave-start="transform opacity-100 scale-100"
+         x-transition:leave-end="transform opacity-0 scale-95"
+         class="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black ring-opacity-5 z-50"
+         role="menu" aria-orientation="vertical" aria-labelledby="language-menu">
+        <div class="py-1" role="none">
+            @foreach($availableLocales as $locale => $name)
+                <button wire:click="switchLanguage('{{ $locale }}')"
+                        class="w-full text-left px-4 py-2 text-sm {{ $currentLocale === $locale ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-white font-semibold' : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700' }}"
+                        role="menuitem">
+                    <span class="flex items-center">
+                        @if($currentLocale === $locale)
+                            <svg class="w-4 h-4 mr-2 text-indigo-600" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+                            </svg>
+                        @else
+                            <span class="w-4 h-4 mr-2"></span>
+                        @endif
+                        {{ $name }}
+                    </span>
+                </button>
+            @endforeach
+        </div>
+    </div>
+</div>

--- a/tests/Feature/LanguageSwitcherTest.php
+++ b/tests/Feature/LanguageSwitcherTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Livewire\LanguageSwitcher;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Session;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+test('language switcher component can switch language', function () {
+    Livewire::test(LanguageSwitcher::class)
+        ->call('switchLanguage', 'es')
+        ->assertRedirect();
+
+    expect(Session::get('locale'))->toBe('es');
+});
+
+test('language switcher validates language code', function () {
+    Session::flush();
+
+    Livewire::test(LanguageSwitcher::class)
+        ->call('switchLanguage', 'invalid');
+
+    // Should not set invalid locale in session
+    expect(Session::get('locale'))->toBeNull();
+});
+
+test('language switcher updates user preference when authenticated', function () {
+    $user = User::factory()->create(['locale' => 'en']);
+
+    $this->actingAs($user);
+
+    Livewire::test(LanguageSwitcher::class)
+        ->call('switchLanguage', 'fr')
+        ->assertRedirect();
+
+    expect($user->fresh()->locale)->toBe('fr');
+});
+
+test('language switcher displays current locale', function () {
+    app()->setLocale('es');
+
+    Livewire::test(LanguageSwitcher::class)
+        ->assertSet('currentLocale', 'es');
+});
+
+test('language switcher displays available locales', function () {
+    Livewire::test(LanguageSwitcher::class)
+        ->assertSet('availableLocales', [
+            'en' => 'English',
+            'es' => 'Español',
+            'fr' => 'Français',
+            'de' => 'Deutsch',
+        ]);
+});

--- a/tests/Feature/LocaleMiddlewareRegistrationTest.php
+++ b/tests/Feature/LocaleMiddlewareRegistrationTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Http\Middleware\SetLocale;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\App;
+
+it('applies a request locale through the registered web middleware group', function () {
+    $this->get('/?locale=es')->assertOk();
+
+    expect(App::getLocale())->toBe('es')
+        ->and(session('locale'))->toBe('es');
+});
+
+it('registers SetLocale on both Filament panels so the authenticated surface localizes', function () {
+    expect(Filament::getPanel('admin')->getMiddleware())->toContain(SetLocale::class)
+        ->and(Filament::getPanel('app')->getMiddleware())->toContain(SetLocale::class);
+});

--- a/tests/Unit/SetLocaleMiddlewareTest.php
+++ b/tests/Unit/SetLocaleMiddlewareTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Http\Middleware\SetLocale;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Session;
+
+uses(RefreshDatabase::class);
+
+test('set locale middleware sets locale from request parameter', function () {
+    $request = Request::create('/test', 'GET', ['locale' => 'es']);
+    $middleware = new SetLocale();
+
+    $middleware->handle($request, function ($req) {
+        expect(App::getLocale())->toBe('es');
+        expect(Session::get('locale'))->toBe('es');
+
+        return response('OK');
+    });
+});
+
+test('set locale middleware sets locale from session', function () {
+    Session::put('locale', 'fr');
+
+    $request = Request::create('/test', 'GET');
+    $middleware = new SetLocale();
+
+    $middleware->handle($request, function ($req) {
+        expect(App::getLocale())->toBe('fr');
+
+        return response('OK');
+    });
+
+    Session::forget('locale');
+});
+
+test('set locale middleware sets locale from the authenticated user preference', function () {
+    $this->actingAs(User::factory()->create(['locale' => 'fr']));
+
+    $request = Request::create('/test', 'GET');
+    $middleware = new SetLocale();
+
+    $middleware->handle($request, function ($req) {
+        expect(App::getLocale())->toBe('fr');
+
+        return response('OK');
+    });
+});
+
+test('set locale middleware validates supported locales', function () {
+    $request = Request::create('/test', 'GET', ['locale' => 'invalid']);
+    $middleware = new SetLocale();
+
+    $middleware->handle($request, function ($req) {
+        // Should fallback to default locale
+        expect(App::getLocale())->toBe('en');
+
+        return response('OK');
+    });
+});
+
+test('set locale middleware detects locale from accept language header', function () {
+    $request = Request::create('/test', 'GET');
+    $request->headers->set('Accept-Language', 'es-ES,es;q=0.9,en;q=0.8');
+
+    $middleware = new SetLocale();
+
+    $middleware->handle($request, function ($req) {
+        expect(App::getLocale())->toBe('es');
+
+        return response('OK');
+    });
+});
+
+test('set locale middleware uses default locale when no preference found', function () {
+    $request = Request::create('/test', 'GET');
+    $middleware = new SetLocale();
+
+    $middleware->handle($request, function ($req) {
+        expect(App::getLocale())->toBe('en');
+
+        return response('OK');
+    });
+});

--- a/tests/Unit/SetLocaleMiddlewareTest.php
+++ b/tests/Unit/SetLocaleMiddlewareTest.php
@@ -37,13 +37,13 @@ test('set locale middleware sets locale from session', function () {
 });
 
 test('set locale middleware sets locale from the authenticated user preference', function () {
-    $this->actingAs(User::factory()->create(['locale' => 'fr']));
+    $this->actingAs(User::factory()->create(['locale' => 'de']));
 
     $request = Request::create('/test', 'GET');
     $middleware = new SetLocale();
 
     $middleware->handle($request, function ($req) {
-        expect(App::getLocale())->toBe('fr');
+        expect(App::getLocale())->toBe('de');
 
         return response('OK');
     });

--- a/tests/Unit/TranslationServiceTest.php
+++ b/tests/Unit/TranslationServiceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Services\TranslationService;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+test('translation service translates text correctly', function () {
+    $service = new TranslationService();
+
+    Http::fake([
+        'api.mymemory.translated.net/*' => Http::response([
+            'responseData' => [
+                'translatedText' => 'Hola',
+            ],
+        ], 200),
+    ]);
+
+    $result = $service->translate('Hello', 'es', 'en');
+
+    expect($result)->toBe('Hola');
+});
+
+test('translation service returns original text if source and target are same', function () {
+    $service = new TranslationService();
+
+    $result = $service->translate('Hello', 'en', 'en');
+
+    expect($result)->toBe('Hello');
+});
+
+test('translation service uses cache', function () {
+    Cache::flush();
+
+    $service = new TranslationService();
+
+    Http::fake([
+        'api.mymemory.translated.net/*' => Http::response([
+            'responseData' => [
+                'translatedText' => 'Hola',
+            ],
+        ], 200),
+    ]);
+
+    // First call should hit the API
+    $result1 = $service->translate('Hello', 'es', 'en');
+
+    // Second call should use cache
+    $result2 = $service->translate('Hello', 'es', 'en');
+
+    expect($result1)->toBe('Hola');
+    expect($result2)->toBe('Hola');
+
+    // Verify cache was used
+    $cacheKey = 'translation:en:es:'.md5('Hello');
+    expect(Cache::has($cacheKey))->toBeTrue();
+});
+
+test('translation service handles API failures gracefully', function () {
+    Cache::flush();
+
+    $service = new TranslationService();
+
+    Http::fake([
+        'api.mymemory.translated.net/*' => Http::response([], 500),
+    ]);
+
+    $result = $service->translate('Hello', 'es', 'en');
+
+    // Should return original text on failure
+    expect($result)->toBe('Hello');
+});
+
+test('translation service can translate batch', function () {
+    $service = new TranslationService();
+
+    Http::fake([
+        'api.mymemory.translated.net/*' => Http::response([
+            'responseData' => [
+                'translatedText' => 'Translated',
+            ],
+        ], 200),
+    ]);
+
+    $texts = [
+        'hello' => 'Hello',
+        'world' => 'World',
+    ];
+
+    $results = $service->translateBatch($texts, 'es', 'en');
+
+    expect($results)->toBeArray();
+    expect($results)->toHaveKey('hello');
+    expect($results)->toHaveKey('world');
+});
+
+test('translation service can check if language is supported', function () {
+    $service = new TranslationService();
+
+    expect($service->isLanguageSupported('en'))->toBeTrue();
+    expect($service->isLanguageSupported('es'))->toBeTrue();
+    expect($service->isLanguageSupported('fr'))->toBeTrue();
+    expect($service->isLanguageSupported('de'))->toBeTrue();
+    expect($service->isLanguageSupported('xx'))->toBeFalse();
+});
+
+test('translation service returns supported languages', function () {
+    $service = new TranslationService();
+
+    $languages = $service->getSupportedLanguages();
+
+    expect($languages)->toBeArray();
+    expect($languages)->toHaveKey('en');
+    expect($languages)->toHaveKey('es');
+    expect($languages)->toHaveKey('fr');
+    expect($languages)->toHaveKey('de');
+});

--- a/tests/Unit/TranslationServiceTest.php
+++ b/tests/Unit/TranslationServiceTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Services\TranslationService;
+use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 
@@ -50,9 +51,23 @@ test('translation service uses cache', function () {
     expect($result1)->toBe('Hola');
     expect($result2)->toBe('Hola');
 
-    // Verify cache was used
+    // The second call must be served from cache — only ONE API request total.
+    Http::assertSentCount(1);
+
     $cacheKey = 'translation:en:es:'.md5('Hello');
     expect(Cache::has($cacheKey))->toBeTrue();
+});
+
+test('translation service returns original text when the API connection throws', function () {
+    Cache::flush();
+
+    $service = new TranslationService();
+
+    Http::fake(function () {
+        throw new ConnectionException('offline');
+    });
+
+    expect($service->translate('Hello', 'es', 'en'))->toBe('Hello');
 });
 
 test('translation service handles API failures gracefully', function () {
@@ -88,9 +103,11 @@ test('translation service can translate batch', function () {
 
     $results = $service->translateBatch($texts, 'es', 'en');
 
-    expect($results)->toBeArray();
-    expect($results)->toHaveKey('hello');
-    expect($results)->toHaveKey('world');
+    expect($results)->toBe([
+        'hello' => 'Translated',
+        'world' => 'Translated',
+    ]);
+    Http::assertSentCount(2);
 });
 
 test('translation service can check if language is supported', function () {


### PR DESCRIPTION
## Phase 3 — Multi-language (i18n)

Stacks on #576 (Phase 2). Base `phase-2-themes`; rebase down the stack as earlier PRs merge.

Ported from `feat/edit-profile-clear-signal` onto the clean base, TDD throughout.

### Included
- `TranslationService` — on-demand translation via the MyMemory API, cached 30 days
- `SetLocale` middleware — resolves locale (request → session → `users.locale` → `Accept-Language` → default, validated against `config('app.supported_locales')`); runs on the **`web` group** AND **both Filament panels**
- `LanguageSwitcher` Livewire component + `users.locale` (fillable + `@property`) + migration
- `config('app.supported_locales')` = en/es/fr/de

### Decisions
- **Big YAGNI cut** (zero callers on source): dropped `locale_helpers.php` + its composer `files` entry, all `lang/*/messages.php` + `validation.php`, the Filament `LanguageSettingsResource`/`ManageLanguageSettings` page + `TranslateLanguageFiles` command, and the i18n docs. Add `lang/` files when something actually calls `__('...')`.

### Verification + review fixes
- phpstan **L9** clean · pint clean · **pest 80 passed / 0 failed**
- Adversarial workflow confirmed locale switching works end-to-end through the real web stack. Findings folded in:
  - **A1 (must-fix):** SetLocale now runs on the Filament panels too (was web-group only → never localized the actual SaaS surface)
  - Strengthened tests that were green for the wrong reasons (cache *read*, batch *values*, exception path, middleware registration)
  - **Security:** session locale written only after validation; switchers redirect only to same-origin Referer (was open-redirect — also hardened the Phase 2 ThemeSwitcher)

### Known / deferred
- The `LanguageSwitcher` component is **not yet mounted in any view** — mount `<livewire:language-switcher />` where a UI is wanted (tracked for a UI phase).
- Precedence is request > session > user (a stale session locale can shadow a freshly-logged-in user until logout flushes the session) — documented.
