### PR TITLE
Phase 4: custom module system (app/Modules + BlogModule)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,15 +73,21 @@ Both panels disable default Fortify/Jetstream route registration in their `boot(
 ### Authentication Stack (layered)
 Fortify handles the authentication primitives, Jetstream adds teams and profile management, Socialstream extends with OAuth providers, and Spatie Permission provides role/permission assignment. The `TeamsPermission` middleware syncs the active team with Filament Shield's tenant context. The `AssignDefaultTeam` middleware ensures every user lands on a team after login.
 
-### Module System (single — `app/Modules/`, target for Phase 4)
+### Module System (Phase 4 — done; single — `app/Modules/`)
 One mechanism: a custom `App\Modules\` system with lifecycle (install/enable/disable/
-uninstall events), a database registry (`modules` table), and `ModuleManager`. Lives under
-the existing `App\` PSR-4 autoload — no per-module `composer.json`, no merge-plugin. The
-`BlogModule` under `app/Modules/BlogModule/` is the reference implementation. Modules hook
-into each other via `HasModuleHooks`; discovery via `ExternalModuleLoader`.
+uninstall, each firing an event), a database registry (`modules` table via `App\Models\Module`),
+and `ModuleManager`. Lives under the existing `App\` PSR-4 autoload — no per-module
+`composer.json`, no merge-plugin. `ModuleManager` discovers modules by scanning `app/Modules/*`
+for a `module.json` (framework subfolders like `Contracts/`, `Events/`, `Traits/` are skipped)
+and resolving the main class as `App\Modules\{Dir}\{Dir}` or `…\{Dir}Module`. The reference is
+`app/Modules/BlogModule/` (`BlogModule.php` + `module.json`) — a thin registry **fixture**; its
+demo controller/routes/views/service were intentionally not ported (the views `@extend` a
+non-existent layout). Modules extend `BaseModule`, implement `ModuleInterface`, and can use the
+`Configurable` + `HasModuleHooks` traits. `ModuleResource` (`app/Filament/Resources/`) is the
+admin UI (`$model = null`, so it needs no tenant opt-out).
 
-`internachi/modular` / `app-modules/` are **not** used (removed in the rebuild). This system
-is **not yet ported** — it is Phase 4 work.
+`internachi/modular` / `app-modules/` are **not** used (removed in the rebuild) — there is no
+`ExternalModuleLoader`.
 
 ### Real-Time Stack
 - **Laravel Reverb** runs as a standalone WebSocket server.

--- a/app/Filament/Resources/ModuleResource.php
+++ b/app/Filament/Resources/ModuleResource.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\ModuleResource\Pages\ListModules;
+use App\Modules\ModuleManager;
+use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Collection;
+
+class ModuleResource extends Resource
+{
+    protected static ?string $model = null;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-puzzle-piece';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'System';
+
+    protected static ?string $navigationLabel = 'Modules';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->disabled(),
+                TextInput::make('version')
+                    ->disabled(),
+                Textarea::make('description')
+                    ->disabled(),
+                Toggle::make('enabled')
+                    ->required(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->records(fn (): Collection => collect(app(ModuleManager::class)->getAllModulesInfo())->keyBy('name'))
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('version')
+                    ->sortable(),
+                TextColumn::make('description')
+                    ->limit(50),
+                IconColumn::make('enabled')
+                    ->boolean()
+                    ->trueIcon('heroicon-o-check-circle')
+                    ->falseIcon('heroicon-o-x-circle')
+                    ->trueColor('success')
+                    ->falseColor('danger'),
+                TextColumn::make('dependencies')
+                    ->formatStateUsing(fn ($state) => is_array($state) ? implode(', ', array_filter($state, 'is_string')) : $state)
+                    ->limit(30),
+            ])
+            ->recordActions([
+                Action::make('toggle')
+                    ->label(fn (array $record) => $record['enabled'] ? 'Disable' : 'Enable')
+                    ->icon(fn (array $record) => $record['enabled'] ? 'heroicon-o-x-circle' : 'heroicon-o-check-circle')
+                    ->color(fn (array $record) => $record['enabled'] ? 'danger' : 'success')
+                    ->action(function (array $record) {
+                        $name = $record['name'] ?? null;
+                        if (! is_string($name)) {
+                            return;
+                        }
+                        $moduleManager = app(ModuleManager::class);
+
+                        if ($record['enabled']) {
+                            $moduleManager->disable($name);
+                        } else {
+                            $moduleManager->enable($name);
+                        }
+                    })
+                    ->requiresConfirmation(),
+                Action::make('install')
+                    ->label('Install')
+                    ->icon('heroicon-o-arrow-down-tray')
+                    ->color('info')
+                    ->action(function (array $record) {
+                        $name = $record['name'] ?? null;
+                        if (is_string($name)) {
+                            app(ModuleManager::class)->install($name);
+                        }
+                    })
+                    ->visible(fn (array $record) => ! $record['enabled'])
+                    ->requiresConfirmation(),
+                Action::make('uninstall')
+                    ->label('Uninstall')
+                    ->icon('heroicon-o-trash')
+                    ->color('danger')
+                    ->action(function (array $record) {
+                        $name = $record['name'] ?? null;
+                        if (is_string($name)) {
+                            app(ModuleManager::class)->uninstall($name);
+                        }
+                    })
+                    ->visible(fn (array $record) => $record['enabled'])
+                    ->requiresConfirmation(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    BulkAction::make('enable')
+                        ->label('Enable Selected')
+                        ->icon('heroicon-o-check-circle')
+                        ->color('success')
+                        ->action(function (Collection $records) {
+                            $moduleManager = app(ModuleManager::class);
+                            foreach ($records as $record) {
+                                $name = is_array($record) ? ($record['name'] ?? null) : null;
+                                if (is_string($name)) {
+                                    $moduleManager->enable($name);
+                                }
+                            }
+                        })
+                        ->requiresConfirmation(),
+                    BulkAction::make('disable')
+                        ->label('Disable Selected')
+                        ->icon('heroicon-o-x-circle')
+                        ->color('danger')
+                        ->action(function (Collection $records) {
+                            $moduleManager = app(ModuleManager::class);
+                            foreach ($records as $record) {
+                                $name = is_array($record) ? ($record['name'] ?? null) : null;
+                                if (is_string($name)) {
+                                    $moduleManager->disable($name);
+                                }
+                            }
+                        })
+                        ->requiresConfirmation(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListModules::route('/'),
+        ];
+    }
+}

--- a/app/Filament/Resources/ModuleResource/Pages/ListModules.php
+++ b/app/Filament/Resources/ModuleResource/Pages/ListModules.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Filament\Resources\ModuleResource\Pages;
+
+use App\Filament\Resources\ModuleResource;
+use Filament\Actions\Action;
+use Filament\Resources\Pages\ListRecords;
+use Filament\Tables\Table;
+
+class ListModules extends ListRecords
+{
+    protected static string $resource = ModuleResource::class;
+
+    /**
+     * Modules are an array data source (not Eloquent), so drop the default
+     * row-click closures that type-hint a Model and would fail on arrays.
+     */
+    protected function makeTable(): Table
+    {
+        return parent::makeTable()
+            ->recordUrl(null)
+            ->recordAction(null);
+    }
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            Action::make('refresh')
+                ->label('Refresh Modules')
+                ->icon('heroicon-o-arrow-path')
+                ->action(function () {
+                    // Clear module cache and reload
+                    cache()->forget('app.modules');
+                    $this->redirect((string) request()->header('Referer'));
+                }),
+        ];
+    }
+}

--- a/app/Models/Module.php
+++ b/app/Models/Module.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string|null $version
+ * @property string|null $description
+ * @property bool $enabled
+ * @property array<int|string, mixed>|null $dependencies
+ * @property array<string, mixed>|null $config
+ */
+class Module extends Model
+{
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'version',
+        'description',
+        'enabled',
+        'dependencies',
+        'config',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'enabled' => 'boolean',
+            'dependencies' => 'array',
+            'config' => 'array',
+        ];
+    }
+
+    public static function findByName(string $name): ?self
+    {
+        return static::where('name', $name)->first();
+    }
+}

--- a/app/Modules/BaseModule.php
+++ b/app/Modules/BaseModule.php
@@ -1,0 +1,403 @@
+<?php
+
+namespace App\Modules;
+
+use App\Models\Module;
+use App\Modules\Contracts\ModuleInterface;
+use App\Modules\Events\ModuleDisabled;
+use App\Modules\Events\ModuleEnabled;
+use App\Modules\Events\ModuleInstalled;
+use App\Modules\Events\ModuleUninstalled;
+use App\Modules\Traits\Configurable;
+use App\Modules\Traits\HasModuleHooks;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use ReflectionClass;
+
+abstract class BaseModule implements ModuleInterface
+{
+    use Configurable, HasModuleHooks;
+
+    protected string $name;
+
+    protected string $version;
+
+    protected string $description;
+
+    /**
+     * @var list<string>
+     */
+    protected array $dependencies = [];
+
+    /**
+     * @var array<string, mixed>
+     */
+    protected array $config = [];
+
+    public function __construct()
+    {
+        $this->loadModuleInfo();
+    }
+
+    /**
+     * Get the module name.
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * Get the module version.
+     */
+    public function getVersion(): string
+    {
+        return $this->version;
+    }
+
+    /**
+     * Get the module description.
+     */
+    public function getDescription(): string
+    {
+        return $this->description;
+    }
+
+    /**
+     * Get the module dependencies.
+     *
+     * @return list<string>
+     */
+    public function getDependencies(): array
+    {
+        return $this->dependencies;
+    }
+
+    /**
+     * Check if the module is enabled.
+     */
+    public function isEnabled(): bool
+    {
+        try {
+            $record = Module::findByName($this->getName());
+            if ($record !== null) {
+                return (bool) $record->enabled;
+            }
+        } catch (\Throwable $e) {
+            Log::debug("Could not read module state from DB for {$this->getName()}: ".$e->getMessage());
+        }
+
+        // Fallback to property if present
+        return (bool) ($this->config['enabled'] ?? false);
+    }
+
+    /**
+     * Enable the module.
+     */
+    public function enable(): void
+    {
+        if ($this->isEnabled()) {
+            Log::info("Module {$this->getName()} is already enabled, skipping enable operation.");
+
+            return;
+        }
+
+        Log::info("Enabling module: {$this->getName()}");
+
+        // Execute before_enable hook
+        $this->executeHook('before_enable', $this);
+
+        // Run onEnable hook
+        try {
+            $this->onEnable();
+            Log::info("Module {$this->getName()} onEnable hook executed successfully.");
+        } catch (\Throwable $e) {
+            $message = "Failed to enable module {$this->getName()}: ".$e->getMessage();
+            Log::error($message, ['module' => $this->getName(), 'exception' => $e]);
+            throw new \RuntimeException($message, 0, $e);
+        }
+
+        // Dispatch event
+        try {
+            event(new ModuleEnabled($this->getName(), $this));
+            Log::info("ModuleEnabled event dispatched for {$this->getName()}");
+        } catch (\Throwable $e) {
+            Log::debug("Failed to dispatch ModuleEnabled event for {$this->getName()}: ".$e->getMessage());
+        }
+
+        // Execute after_enable hook
+        $this->executeHook('after_enable', $this);
+    }
+
+    /**
+     * Disable the module.
+     */
+    public function disable(): void
+    {
+        if (! $this->isEnabled()) {
+            return;
+        }
+
+        // Execute before_disable hook
+        $this->executeHook('before_disable', $this);
+
+        try {
+            $this->onDisable();
+        } catch (\Throwable $e) {
+            Log::warning("onDisable failed for {$this->getName()}: ".$e->getMessage());
+        }
+
+        try {
+            event(new ModuleDisabled($this->getName(), $this));
+        } catch (\Throwable $e) {
+            Log::debug("Failed to dispatch ModuleDisabled event for {$this->getName()}: ".$e->getMessage());
+        }
+
+        // Execute after_disable hook
+        $this->executeHook('after_disable', $this);
+    }
+
+    /**
+     * Install the module.
+     */
+    public function install(): void
+    {
+        Log::info("Installing module: {$this->getName()}");
+
+        // Execute before_install hook
+        $this->executeHook('before_install', $this);
+
+        try {
+            $this->runMigrations();
+            Log::info("Migrations completed for module: {$this->getName()}");
+        } catch (\Throwable $e) {
+            Log::error("Migration failed for module {$this->getName()}: ".$e->getMessage());
+            throw $e;
+        }
+
+        try {
+            $this->publishAssets();
+            Log::info("Assets published for module: {$this->getName()}");
+        } catch (\Throwable $e) {
+            Log::warning("Asset publishing failed for module {$this->getName()}: ".$e->getMessage());
+            // Continue anyway - assets are optional
+        }
+
+        $this->onInstall();
+        $this->enable();
+
+        try {
+            event(new ModuleInstalled($this->getName(), $this));
+        } catch (\Throwable $e) {
+            Log::debug("Failed to dispatch ModuleInstalled event for {$this->getName()}: ".$e->getMessage());
+        }
+
+        // Execute after_install hook
+        $this->executeHook('after_install', $this);
+
+        Log::info("Module {$this->getName()} installed successfully");
+    }
+
+    /**
+     * Uninstall the module.
+     */
+    public function uninstall(): void
+    {
+        // Execute before_uninstall hook
+        $this->executeHook('before_uninstall', $this);
+
+        $this->disable();
+        $this->rollbackMigrations();
+        $this->removeAssets();
+        $this->onUninstall();
+
+        try {
+            event(new ModuleUninstalled($this->getName(), $this));
+        } catch (\Throwable $e) {
+            Log::debug("Failed to dispatch ModuleUninstalled event for {$this->getName()}: ".$e->getMessage());
+        }
+
+        // Execute after_uninstall hook
+        $this->executeHook('after_uninstall', $this);
+    }
+
+    /**
+     * Get module configuration.
+     *
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * Load module information from module.json file.
+     */
+    protected function loadModuleInfo(): void
+    {
+        $modulePath = $this->getModulePath();
+        $moduleInfoPath = $modulePath.'/module.json';
+
+        if (! File::exists($moduleInfoPath)) {
+            return;
+        }
+
+        $moduleInfo = json_decode(File::get($moduleInfoPath), true);
+
+        if (! is_array($moduleInfo)) {
+            return;
+        }
+
+        $this->name = is_string($moduleInfo['name'] ?? null) ? $moduleInfo['name'] : class_basename($this);
+        $this->version = is_string($moduleInfo['version'] ?? null) ? $moduleInfo['version'] : '1.0.0';
+        $this->description = is_string($moduleInfo['description'] ?? null) ? $moduleInfo['description'] : '';
+
+        $deps = $moduleInfo['dependencies'] ?? [];
+        $this->dependencies = is_array($deps)
+            ? array_values(array_filter($deps, 'is_string'))
+            : [];
+
+        $config = [];
+        $rawConfig = $moduleInfo['config'] ?? [];
+        if (is_array($rawConfig)) {
+            foreach ($rawConfig as $key => $value) {
+                $config[(string) $key] = $value;
+            }
+        }
+        $this->config = $config;
+    }
+
+    /**
+     * Get the module path.
+     */
+    protected function getModulePath(): string
+    {
+        $reflection = new ReflectionClass($this);
+
+        return dirname((string) $reflection->getFileName());
+    }
+
+    /**
+     * Run module migrations.
+     */
+    protected function runMigrations(): void
+    {
+        // Validate module name to prevent path traversal
+        if (! preg_match('/^[a-zA-Z0-9_-]+$/', $this->name)) {
+            Log::error("Invalid module name for migrations: {$this->name}");
+            throw new \InvalidArgumentException("Invalid module name: {$this->name}");
+        }
+
+        $migrationsPath = $this->getModulePath().'/database/migrations';
+
+        if (! File::exists($migrationsPath)) {
+            return;
+        }
+
+        // Double-check the path is within app/Modules for defense in depth
+        $expectedPath = app_path('Modules/'.$this->name);
+        $moduleReal = realpath($this->getModulePath());
+        $expectedReal = realpath($expectedPath);
+        if ($moduleReal === false || $expectedReal === false || strpos($moduleReal, $expectedReal) !== 0) {
+            Log::error("Module path validation failed for: {$this->name}");
+            throw new \RuntimeException('Invalid module path');
+        }
+
+        Artisan::call('migrate', [
+            '--path' => 'app/Modules/'.$this->name.'/database/migrations',
+            '--force' => true,
+        ]);
+    }
+
+    /**
+     * Rollback module migrations.
+     */
+    protected function rollbackMigrations(): void
+    {
+        // Validate module name to prevent path traversal
+        if (! preg_match('/^[a-zA-Z0-9_-]+$/', $this->name)) {
+            Log::error("Invalid module name for migration rollback: {$this->name}");
+            throw new \InvalidArgumentException("Invalid module name: {$this->name}");
+        }
+
+        $migrationsPath = $this->getModulePath().'/database/migrations';
+
+        if (! File::exists($migrationsPath)) {
+            return;
+        }
+
+        // Double-check the path is within app/Modules for defense in depth
+        $expectedPath = app_path('Modules/'.$this->name);
+        $moduleReal = realpath($this->getModulePath());
+        $expectedReal = realpath($expectedPath);
+        if ($moduleReal === false || $expectedReal === false || strpos($moduleReal, $expectedReal) !== 0) {
+            Log::error("Module path validation failed for: {$this->name}");
+            throw new \RuntimeException('Invalid module path');
+        }
+
+        try {
+            Artisan::call('migrate:rollback', [
+                '--path' => 'app/Modules/'.$this->name.'/database/migrations',
+                '--force' => true,
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning("Failed to rollback migrations for {$this->getName()}: ".$e->getMessage());
+        }
+    }
+
+    /**
+     * Publish module assets.
+     */
+    protected function publishAssets(): void
+    {
+        Artisan::call('vendor:publish', [
+            '--tag' => strtolower($this->name).'-assets',
+            '--force' => true,
+        ]);
+    }
+
+    /**
+     * Remove module assets.
+     */
+    protected function removeAssets(): void
+    {
+        $assetsPath = public_path("modules/{$this->name}");
+        if (File::exists($assetsPath)) {
+            File::deleteDirectory($assetsPath);
+        }
+    }
+
+    /**
+     * Hook called when module is enabled.
+     */
+    protected function onEnable(): void
+    {
+        // Override in child classes
+    }
+
+    /**
+     * Hook called when module is disabled.
+     */
+    protected function onDisable(): void
+    {
+        // Override in child classes
+    }
+
+    /**
+     * Hook called when module is installed.
+     */
+    protected function onInstall(): void
+    {
+        // Override in child classes
+    }
+
+    /**
+     * Hook called when module is uninstalled.
+     */
+    protected function onUninstall(): void
+    {
+        // Override in child classes
+    }
+}

--- a/app/Modules/BlogModule/BlogModule.php
+++ b/app/Modules/BlogModule/BlogModule.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Modules\BlogModule;
+
+use App\Modules\BaseModule;
+use Illuminate\Support\Facades\Log;
+
+class BlogModule extends BaseModule
+{
+    protected function onEnable(): void
+    {
+        // Called when module is enabled
+        Log::info('Blog module has been enabled');
+    }
+
+    protected function onDisable(): void
+    {
+        // Called when module is disabled
+        Log::info('Blog module has been disabled');
+    }
+
+    protected function onInstall(): void
+    {
+        // Called when module is installed
+        Log::info('Blog module has been installed');
+    }
+
+    protected function onUninstall(): void
+    {
+        // Called when module is uninstalled
+        Log::info('Blog module has been uninstalled');
+    }
+}

--- a/app/Modules/BlogModule/module.json
+++ b/app/Modules/BlogModule/module.json
@@ -1,0 +1,11 @@
+{
+    "name": "BlogModule",
+    "version": "1.0.0",
+    "description": "A simple blog module for demonstration",
+    "dependencies": [],
+    "config": {
+        "posts_per_page": 10,
+        "allow_comments": true,
+        "moderation_enabled": false
+    }
+}

--- a/app/Modules/Contracts/ModuleInterface.php
+++ b/app/Modules/Contracts/ModuleInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Modules\Contracts;
+
+interface ModuleInterface
+{
+    /**
+     * Get the module name.
+     */
+    public function getName(): string;
+
+    /**
+     * Get the module version.
+     */
+    public function getVersion(): string;
+
+    /**
+     * Get the module description.
+     */
+    public function getDescription(): string;
+
+    /**
+     * Get the module dependencies.
+     *
+     * @return list<string>
+     */
+    public function getDependencies(): array;
+
+    /**
+     * Check if the module is enabled.
+     */
+    public function isEnabled(): bool;
+
+    /**
+     * Enable the module.
+     */
+    public function enable(): void;
+
+    /**
+     * Disable the module.
+     */
+    public function disable(): void;
+
+    /**
+     * Install the module.
+     */
+    public function install(): void;
+
+    /**
+     * Uninstall the module.
+     */
+    public function uninstall(): void;
+
+    /**
+     * Get module configuration.
+     *
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array;
+}

--- a/app/Modules/Events/ModuleDisabled.php
+++ b/app/Modules/Events/ModuleDisabled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+
+class ModuleDisabled
+{
+    public string $name;
+
+    public ModuleInterface $module;
+
+    public function __construct(string $name, ModuleInterface $module)
+    {
+        $this->name = $name;
+        $this->module = $module;
+    }
+}

--- a/app/Modules/Events/ModuleEnabled.php
+++ b/app/Modules/Events/ModuleEnabled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+
+class ModuleEnabled
+{
+    public string $name;
+
+    public ModuleInterface $module;
+
+    public function __construct(string $name, ModuleInterface $module)
+    {
+        $this->name = $name;
+        $this->module = $module;
+    }
+}

--- a/app/Modules/Events/ModuleInstalled.php
+++ b/app/Modules/Events/ModuleInstalled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+
+class ModuleInstalled
+{
+    public string $name;
+
+    public ModuleInterface $module;
+
+    public function __construct(string $name, ModuleInterface $module)
+    {
+        $this->name = $name;
+        $this->module = $module;
+    }
+}

--- a/app/Modules/Events/ModuleUninstalled.php
+++ b/app/Modules/Events/ModuleUninstalled.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Modules\Events;
+
+use App\Modules\Contracts\ModuleInterface;
+
+class ModuleUninstalled
+{
+    public string $name;
+
+    public ModuleInterface $module;
+
+    public function __construct(string $name, ModuleInterface $module)
+    {
+        $this->name = $name;
+        $this->module = $module;
+    }
+}

--- a/app/Modules/ModuleManager.php
+++ b/app/Modules/ModuleManager.php
@@ -1,0 +1,405 @@
+<?php
+
+namespace App\Modules;
+
+use App\Models\Module;
+use App\Modules\Contracts\ModuleInterface;
+use Exception;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+
+class ModuleManager
+{
+    /**
+     * @var Collection<string, ModuleInterface>
+     */
+    protected Collection $modules;
+
+    public function __construct()
+    {
+        $this->modules = new Collection();
+        $this->loadModules();
+    }
+
+    /**
+     * Get all modules.
+     *
+     * @return Collection<string, ModuleInterface>
+     */
+    public function all(): Collection
+    {
+        return $this->modules;
+    }
+
+    /**
+     * Get enabled modules.
+     *
+     * @return Collection<string, ModuleInterface>
+     */
+    public function enabled(): Collection
+    {
+        return $this->modules->filter(fn (ModuleInterface $module) => $module->isEnabled());
+    }
+
+    /**
+     * Get disabled modules.
+     *
+     * @return Collection<string, ModuleInterface>
+     */
+    public function disabled(): Collection
+    {
+        return $this->modules->filter(fn (ModuleInterface $module) => ! $module->isEnabled());
+    }
+
+    /**
+     * Get a specific module by name.
+     */
+    public function get(string $name): ?ModuleInterface
+    {
+        return $this->modules->first(fn (ModuleInterface $module) => $module->getName() === $name);
+    }
+
+    /**
+     * Find a module by name (alias for get).
+     */
+    public function find(string $name): ?ModuleInterface
+    {
+        return $this->get($name);
+    }
+
+    /**
+     * Check if a module exists.
+     */
+    public function has(string $name): bool
+    {
+        return $this->modules->contains(fn (ModuleInterface $module) => $module->getName() === $name);
+    }
+
+    /**
+     * Enable a module.
+     */
+    public function enable(string $name): bool
+    {
+        $module = $this->get($name);
+
+        if (! $module) {
+            return false;
+        }
+
+        // Check dependencies
+        if (! $this->checkDependencies($module)) {
+            throw new Exception("Module {$name} has unmet dependencies.");
+        }
+
+        $module->enable();
+
+        // Persist enabled state
+        try {
+            $mdl = Module::firstOrNew(['name' => $module->getName()]);
+            $mdl->enabled = true;
+            $mdl->version = $module->getVersion();
+            $mdl->description = $module->getDescription();
+            $mdl->dependencies = $module->getDependencies();
+            $mdl->config = $module->getConfig();
+            $mdl->save();
+        } catch (\Throwable $e) {
+            Log::warning("Failed to persist enabled state for module '{$name}': ".$e->getMessage());
+        }
+
+        return true;
+    }
+
+    /**
+     * Disable a module.
+     */
+    public function disable(string $name): bool
+    {
+        $module = $this->get($name);
+
+        if (! $module) {
+            return false;
+        }
+
+        // Check if other modules depend on this one
+        if ($this->hasDependents($name)) {
+            throw new Exception("Cannot disable module {$name} as other modules depend on it.");
+        }
+
+        $module->disable();
+
+        // Persist enabled state
+        try {
+            $mdl = Module::firstOrNew(['name' => $module->getName()]);
+            $mdl->enabled = false;
+            $mdl->save();
+        } catch (\Throwable $e) {
+            Log::warning("Failed to persist disabled state for module '{$name}': ".$e->getMessage());
+        }
+
+        return true;
+    }
+
+    /**
+     * Install a module.
+     */
+    public function install(string $name): bool
+    {
+        $module = $this->get($name);
+
+        if (! $module) {
+            return false;
+        }
+
+        // Check dependencies
+        if (! $this->checkDependencies($module)) {
+            throw new Exception("Module {$name} has unmet dependencies.");
+        }
+
+        $module->install();
+
+        return true;
+    }
+
+    /**
+     * Uninstall a module.
+     */
+    public function uninstall(string $name): bool
+    {
+        $module = $this->get($name);
+
+        if (! $module) {
+            return false;
+        }
+
+        // Check if other modules depend on this one
+        if ($this->hasDependents($name)) {
+            throw new Exception("Cannot uninstall module {$name} as other modules depend on it.");
+        }
+
+        $module->uninstall();
+
+        return true;
+    }
+
+    /**
+     * Register a new module.
+     */
+    public function register(ModuleInterface $module): void
+    {
+        $this->modules->put($module->getName(), $module);
+    }
+
+    /**
+     * Load all modules from the modules directory.
+     */
+    protected function loadModules(): void
+    {
+        $cacheKey = config('modules.cache_key', 'app.modules');
+        $cacheKey = is_string($cacheKey) ? $cacheKey : 'app.modules';
+
+        // Check if caching is enabled
+        if (config('modules.cache', true) && ! config('modules.development', false)) {
+            $cachedModules = Cache::get($cacheKey);
+
+            if (is_array($cachedModules)) {
+                /** @var Collection<string, ModuleInterface> $restored */
+                $restored = new Collection($cachedModules);
+                $this->modules = $restored;
+
+                return;
+            }
+        }
+
+        // Load from the modules directory (app/Modules)
+        $modulesPath = app_path('Modules');
+        if (File::exists($modulesPath)) {
+            $modules = File::directories($modulesPath);
+            foreach ($modules as $modulePath) {
+                $moduleName = basename($modulePath);
+                $this->loadModule($moduleName, $modulePath);
+            }
+        }
+
+        // Cache the loaded modules
+        if (config('modules.cache', true) && ! config('modules.development', false)) {
+            $ttl = config('modules.cache_ttl', 3600);
+            Cache::put(
+                $cacheKey,
+                $this->modules->all(),
+                is_int($ttl) ? $ttl : 3600
+            );
+        }
+    }
+
+    /**
+     * Load a specific module.
+     */
+    protected function loadModule(string $moduleName, string $modulePath): void
+    {
+        $moduleClass = "App\\Modules\\{$moduleName}\\{$moduleName}Module";
+
+        // If class isn't autoloadable, try requiring the module main file directly.
+        if (! class_exists($moduleClass)) {
+            $mainFile = $modulePath."/{$moduleName}Module.php";
+            if (File::exists($mainFile)) {
+                try {
+                    require_once $mainFile;
+                } catch (\Throwable $e) {
+                    Log::warning("Failed requiring main file for module {$moduleName}: ".$e->getMessage());
+                }
+            }
+        }
+
+        if (class_exists($moduleClass)) {
+            try {
+                $module = new $moduleClass();
+            } catch (\Throwable $e) {
+                Log::warning("Failed instantiating module class {$moduleClass}: ".$e->getMessage());
+
+                return;
+            }
+
+            if ($module instanceof ModuleInterface) {
+                $this->register($module);
+
+                // Persist module metadata to DB (create or update)
+                try {
+                    Module::updateOrCreate(
+                        ['name' => $module->getName()],
+                        [
+                            'version' => $module->getVersion(),
+                            'description' => $module->getDescription(),
+                            'dependencies' => $module->getDependencies(),
+                            'config' => $module->getConfig(),
+                        ]
+                    );
+                } catch (\Throwable $e) {
+                    Log::warning("Failed to persist module '{$moduleName}' metadata: ".$e->getMessage());
+                }
+            }
+        } else {
+            Log::warning("Module class {$moduleClass} not found for module path {$modulePath}.");
+        }
+    }
+
+    /**
+     * Check if module dependencies are met.
+     */
+    protected function checkDependencies(ModuleInterface $module): bool
+    {
+        foreach ($module->getDependencies() as $dependency) {
+            $dependencyModule = $this->get($dependency);
+            if (! $dependencyModule || ! $dependencyModule->isEnabled()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if any modules depend on the given module.
+     */
+    protected function hasDependents(string $moduleName): bool
+    {
+        return $this->enabled()->contains(function (ModuleInterface $module) use ($moduleName) {
+            return in_array($moduleName, $module->getDependencies(), true);
+        });
+    }
+
+    /**
+     * Get module information for display.
+     *
+     * @return array<string, mixed>
+     */
+    public function getModuleInfo(string $name): array
+    {
+        $module = $this->get($name);
+
+        if (! $module) {
+            return [];
+        }
+
+        return [
+            'name' => $module->getName(),
+            'version' => $module->getVersion(),
+            'description' => $module->getDescription(),
+            'dependencies' => $module->getDependencies(),
+            'enabled' => $module->isEnabled(),
+            'config' => $module->getConfig(),
+        ];
+    }
+
+    /**
+     * Get all modules information.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public function getAllModulesInfo(): array
+    {
+        /** @var array<int, array<string, mixed>> $info */
+        $info = $this->modules->map(function (ModuleInterface $module) {
+            return $this->getModuleInfo($module->getName());
+        })->values()->toArray();
+
+        return $info;
+    }
+
+    /**
+     * Clear the module cache.
+     */
+    public function clearCache(): void
+    {
+        $cacheKey = config('modules.cache_key', 'app.modules');
+        Cache::forget(is_string($cacheKey) ? $cacheKey : 'app.modules');
+    }
+
+    /**
+     * Check module health status.
+     *
+     * @return array<string, mixed>
+     */
+    public function checkHealth(string $name): array
+    {
+        $module = $this->get($name);
+
+        if (! $module) {
+            return [
+                'healthy' => false,
+                'errors' => ['Module not found'],
+            ];
+        }
+
+        $errors = [];
+        $warnings = [];
+
+        // Check if module class exists
+        $moduleClass = get_class($module);
+        if (! class_exists($moduleClass)) {
+            $errors[] = "Module class {$moduleClass} not found";
+        }
+
+        // Check dependencies
+        foreach ($module->getDependencies() as $dependency) {
+            $dependencyModule = $this->get($dependency);
+            if (! $dependencyModule) {
+                $errors[] = "Dependency {$dependency} not found";
+            } elseif (! $dependencyModule->isEnabled()) {
+                $warnings[] = "Dependency {$dependency} is disabled";
+            }
+        }
+
+        // Check if module is enabled but has unmet dependencies
+        if ($module->isEnabled() && ! $this->checkDependencies($module)) {
+            $errors[] = 'Module is enabled but has unmet dependencies';
+        }
+
+        return [
+            'healthy' => empty($errors),
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+}

--- a/app/Modules/ModuleManager.php
+++ b/app/Modules/ModuleManager.php
@@ -238,50 +238,86 @@ class ModuleManager
      */
     protected function loadModule(string $moduleName, string $modulePath): void
     {
-        $moduleClass = "App\\Modules\\{$moduleName}\\{$moduleName}Module";
+        // Only directories that declare a module.json are modules — skip the framework
+        // subfolders (Contracts/, Events/, Traits/, Support/).
+        if (! File::exists($modulePath.'/module.json')) {
+            return;
+        }
 
-        // If class isn't autoloadable, try requiring the module main file directly.
-        if (! class_exists($moduleClass)) {
-            $mainFile = $modulePath."/{$moduleName}Module.php";
-            if (File::exists($mainFile)) {
-                try {
-                    require_once $mainFile;
-                } catch (\Throwable $e) {
-                    Log::warning("Failed requiring main file for module {$moduleName}: ".$e->getMessage());
+        // Support both layouts: app/Modules/Foo/FooModule.php and app/Modules/Foo/Foo.php.
+        $candidates = [
+            "App\\Modules\\{$moduleName}\\{$moduleName}Module",
+            "App\\Modules\\{$moduleName}\\{$moduleName}",
+        ];
+
+        $moduleClass = $this->resolveModuleClass($candidates);
+
+        // If not autoloadable, require the main file directly, then re-check.
+        if ($moduleClass === null) {
+            foreach (["{$moduleName}Module.php", "{$moduleName}.php"] as $file) {
+                $mainFile = $modulePath.'/'.$file;
+                if (File::exists($mainFile)) {
+                    try {
+                        require_once $mainFile;
+                    } catch (\Throwable $e) {
+                        Log::warning("Failed requiring main file for module {$moduleName}: ".$e->getMessage());
+                    }
                 }
+            }
+            $moduleClass = $this->resolveModuleClass($candidates);
+        }
+
+        if ($moduleClass === null) {
+            Log::warning("Module class not found for module path {$modulePath}.");
+
+            return;
+        }
+
+        try {
+            $module = new $moduleClass();
+        } catch (\Throwable $e) {
+            Log::warning("Failed instantiating module class {$moduleClass}: ".$e->getMessage());
+
+            return;
+        }
+
+        if (! $module instanceof ModuleInterface) {
+            return;
+        }
+
+        $this->register($module);
+
+        // Persist module metadata to DB (create or update).
+        try {
+            Module::updateOrCreate(
+                ['name' => $module->getName()],
+                [
+                    'version' => $module->getVersion(),
+                    'description' => $module->getDescription(),
+                    'dependencies' => $module->getDependencies(),
+                    'config' => $module->getConfig(),
+                ]
+            );
+        } catch (\Throwable $e) {
+            Log::warning("Failed to persist module '{$moduleName}' metadata: ".$e->getMessage());
+        }
+    }
+
+    /**
+     * Return the first existing class from the candidate list, or null.
+     *
+     * @param  list<string>  $candidates
+     * @return class-string|null
+     */
+    protected function resolveModuleClass(array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            if (class_exists($candidate)) {
+                return $candidate;
             }
         }
 
-        if (class_exists($moduleClass)) {
-            try {
-                $module = new $moduleClass();
-            } catch (\Throwable $e) {
-                Log::warning("Failed instantiating module class {$moduleClass}: ".$e->getMessage());
-
-                return;
-            }
-
-            if ($module instanceof ModuleInterface) {
-                $this->register($module);
-
-                // Persist module metadata to DB (create or update)
-                try {
-                    Module::updateOrCreate(
-                        ['name' => $module->getName()],
-                        [
-                            'version' => $module->getVersion(),
-                            'description' => $module->getDescription(),
-                            'dependencies' => $module->getDependencies(),
-                            'config' => $module->getConfig(),
-                        ]
-                    );
-                } catch (\Throwable $e) {
-                    Log::warning("Failed to persist module '{$moduleName}' metadata: ".$e->getMessage());
-                }
-            }
-        } else {
-            Log::warning("Module class {$moduleClass} not found for module path {$modulePath}.");
-        }
+        return null;
     }
 
     /**

--- a/app/Modules/ModuleServiceProvider.php
+++ b/app/Modules/ModuleServiceProvider.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace App\Modules;
+
+use App\Models\Module;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
+
+class ModuleServiceProvider extends ServiceProvider
+{
+    /**
+     * Register any application services.
+     */
+    public function register(): void
+    {
+        $this->registerModules();
+    }
+
+    /**
+     * Bootstrap any application services.
+     */
+    public function boot(): void
+    {
+        $this->bootModules();
+    }
+
+    /**
+     * Register all modules found in the modules directory.
+     */
+    protected function registerModules(): void
+    {
+        $modulesPath = app_path('Modules');
+
+        if (! File::exists($modulesPath)) {
+            return;
+        }
+
+        $modules = File::directories($modulesPath);
+
+        foreach ($modules as $modulePath) {
+            $moduleName = basename($modulePath);
+            $this->registerModule($moduleName, $modulePath);
+        }
+    }
+
+    /**
+     * Register a specific module.
+     */
+    protected function registerModule(string $moduleName, string $modulePath): void
+    {
+        // Check if module is enabled before loading routes/views
+        $isEnabled = $this->isModuleEnabled($moduleName);
+
+        // Register module service provider if it exists
+        $providerPath = $modulePath.'/Providers/'.$moduleName.'ServiceProvider.php';
+        if (File::exists($providerPath)) {
+            $providerClass = "App\\Modules\\{$moduleName}\\Providers\\{$moduleName}ServiceProvider";
+            if (class_exists($providerClass)) {
+                $this->app->register($providerClass);
+            }
+        }
+
+        // Register module configuration (always load configuration)
+        $configPath = $modulePath.'/config';
+        if (File::exists($configPath)) {
+            $configFiles = File::files($configPath);
+            foreach ($configFiles as $configFile) {
+                $configName = Str::snake($moduleName).'.'.$configFile->getFilenameWithoutExtension();
+                $this->mergeConfigFrom($configFile->getPathname(), $configName);
+            }
+        }
+
+        // Only register routes and views for enabled modules
+        if ($isEnabled) {
+            // Register module routes
+            $this->registerModuleRoutes($moduleName, $modulePath);
+
+            // Register module views
+            $viewsPath = $modulePath.'/resources/views';
+            if (File::exists($viewsPath)) {
+                $this->loadViewsFrom($viewsPath, Str::snake($moduleName));
+            }
+
+            // Register module translations
+            $langPath = $modulePath.'/resources/lang';
+            if (File::exists($langPath)) {
+                $this->loadTranslationsFrom($langPath, Str::snake($moduleName));
+            }
+        }
+
+        // Register module migrations (always available for artisan commands)
+        $migrationsPath = $modulePath.'/database/migrations';
+        if (File::exists($migrationsPath)) {
+            $this->loadMigrationsFrom($migrationsPath);
+        }
+    }
+
+    /**
+     * Register module routes.
+     */
+    protected function registerModuleRoutes(string $moduleName, string $modulePath): void
+    {
+        $routesPath = $modulePath.'/routes';
+
+        if (! File::exists($routesPath)) {
+            return;
+        }
+
+        // Web routes
+        $webRoutesPath = $routesPath.'/web.php';
+        if (File::exists($webRoutesPath)) {
+            $this->loadRoutesFrom($webRoutesPath);
+        }
+
+        // API routes
+        $apiRoutesPath = $routesPath.'/api.php';
+        if (File::exists($apiRoutesPath)) {
+            $this->loadRoutesFrom($apiRoutesPath);
+        }
+
+        // Admin routes (for Filament integration)
+        $adminRoutesPath = $routesPath.'/admin.php';
+        if (File::exists($adminRoutesPath)) {
+            $this->loadRoutesFrom($adminRoutesPath);
+        }
+    }
+
+    /**
+     * Boot all registered modules.
+     */
+    protected function bootModules(): void
+    {
+        $modulesPath = app_path('Modules');
+
+        if (! File::exists($modulesPath)) {
+            return;
+        }
+
+        $modules = File::directories($modulesPath);
+
+        foreach ($modules as $modulePath) {
+            $moduleName = basename($modulePath);
+            $this->bootModule($moduleName, $modulePath);
+        }
+    }
+
+    /**
+     * Boot a specific module.
+     */
+    protected function bootModule(string $moduleName, string $modulePath): void
+    {
+        // Publish module assets
+        $assetsPath = $modulePath.'/resources/assets';
+        if (File::exists($assetsPath)) {
+            $this->publishes([
+                $assetsPath => public_path("modules/{$moduleName}"),
+            ], Str::snake($moduleName).'-assets');
+        }
+
+        // Publish module configuration
+        $configPath = $modulePath.'/config';
+        if (File::exists($configPath)) {
+            $configFiles = File::files($configPath);
+            foreach ($configFiles as $configFile) {
+                $this->publishes([
+                    $configFile->getPathname() => config_path(Str::snake($moduleName).'.'.$configFile->getFilename()),
+                ], Str::snake($moduleName).'-config');
+            }
+        }
+    }
+
+    /**
+     * Check if a module is enabled.
+     */
+    protected function isModuleEnabled(string $moduleName): bool
+    {
+        try {
+            // Check database for module enabled status
+            $record = Module::where('name', $moduleName)->first();
+            if ($record !== null) {
+                return (bool) $record->enabled;
+            }
+        } catch (\Throwable $e) {
+            // Database may not be set up yet, or Module table doesn't exist
+            // In this case, we default to loading the module
+        }
+
+        // Default to enabled if no database record exists
+        return true;
+    }
+}

--- a/app/Modules/Traits/Configurable.php
+++ b/app/Modules/Traits/Configurable.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Modules\Traits;
+
+use Illuminate\Support\Facades\Config;
+
+/**
+ * Trait Configurable
+ *
+ * Provides configuration management for modules.
+ */
+trait Configurable
+{
+    /**
+     * Get a configuration value for the module.
+     *
+     * @param  string  $key  The configuration key
+     * @param  mixed  $default  Default value if key not found
+     */
+    public function config(string $key, mixed $default = null): mixed
+    {
+        $moduleName = strtolower($this->getName());
+
+        return Config::get("{$moduleName}.{$key}", $default);
+    }
+
+    /**
+     * Set a runtime configuration value for the module.
+     *
+     * @param  string  $key  The configuration key
+     * @param  mixed  $value  The value to set
+     */
+    public function setConfig(string $key, mixed $value): void
+    {
+        $moduleName = strtolower($this->getName());
+        Config::set("{$moduleName}.{$key}", $value);
+    }
+
+    /**
+     * Check if a configuration key exists.
+     */
+    public function hasConfig(string $key): bool
+    {
+        $moduleName = strtolower($this->getName());
+
+        return Config::has("{$moduleName}.{$key}");
+    }
+
+    /**
+     * Get all configuration for the module.
+     *
+     * @return array<string, mixed>
+     */
+    public function getAllConfig(): array
+    {
+        $moduleName = strtolower($this->getName());
+        $value = Config::get($moduleName, []);
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $value */
+        return $value;
+    }
+
+    /**
+     * Merge configuration array into module config.
+     *
+     * @param  array<string, mixed>  $config
+     */
+    public function mergeConfig(array $config): void
+    {
+        $moduleName = strtolower($this->getName());
+        $existing = Config::get($moduleName, []);
+        $existing = is_array($existing) ? $existing : [];
+        Config::set($moduleName, array_merge($existing, $config));
+    }
+}

--- a/app/Modules/Traits/HasModuleHooks.php
+++ b/app/Modules/Traits/HasModuleHooks.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Modules\Traits;
+
+/**
+ * Trait HasModuleHooks
+ *
+ * Provides a flexible hook system for modules to extend functionality
+ * at various lifecycle points.
+ */
+trait HasModuleHooks
+{
+    /**
+     * Registered hooks.
+     *
+     * @var array<string, list<array{callback:callable,priority:int}>>
+     */
+    protected array $hooks = [];
+
+    /**
+     * Register a hook callback.
+     *
+     * @param  string  $hookName  The name of the hook
+     * @param  callable  $callback  The callback to execute
+     * @param  int  $priority  Priority of execution (lower = earlier)
+     */
+    public function registerHook(string $hookName, callable $callback, int $priority = 10): void
+    {
+        if (! isset($this->hooks[$hookName])) {
+            $this->hooks[$hookName] = [];
+        }
+
+        $this->hooks[$hookName][] = [
+            'callback' => $callback,
+            'priority' => $priority,
+        ];
+
+        // Sort by priority
+        usort($this->hooks[$hookName], fn ($a, $b) => $a['priority'] <=> $b['priority']);
+    }
+
+    /**
+     * Execute all callbacks for a hook.
+     *
+     * @param  string  $hookName  The hook name
+     * @param  mixed  ...$args  Arguments to pass to callbacks
+     * @return mixed The result from the last callback, or null
+     */
+    public function executeHook(string $hookName, ...$args): mixed
+    {
+        if (! isset($this->hooks[$hookName])) {
+            return null;
+        }
+
+        $result = null;
+        foreach ($this->hooks[$hookName] as $hook) {
+            $result = call_user_func_array($hook['callback'], $args);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Check if a hook has callbacks registered.
+     */
+    public function hasHook(string $hookName): bool
+    {
+        return isset($this->hooks[$hookName]) && count($this->hooks[$hookName]) > 0;
+    }
+
+    /**
+     * Remove all callbacks for a hook.
+     */
+    public function clearHook(string $hookName): void
+    {
+        unset($this->hooks[$hookName]);
+    }
+
+    /**
+     * Get all registered hooks.
+     *
+     * @return list<string>
+     */
+    public function getHooks(): array
+    {
+        return array_keys($this->hooks);
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Modules\ModuleServiceProvider;
 use App\Providers\AppServiceProvider;
 use App\Providers\Filament\AdminPanelProvider;
 use App\Providers\Filament\AppPanelProvider;
@@ -18,4 +19,5 @@ return [
     SocialstreamServiceProvider::class,
     TelescopeServiceProvider::class,
     ThemeServiceProvider::class,
+    ModuleServiceProvider::class,
 ];

--- a/config/modules.php
+++ b/config/modules.php
@@ -1,0 +1,50 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Modules Path
+    |--------------------------------------------------------------------------
+    |
+    | The path where modules are stored. By default, modules live in the
+    | app/Modules directory.
+    |
+    */
+
+    'path' => app_path('Modules'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Development Mode
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, modules are reloaded on each request (caching is skipped).
+    |
+    */
+
+    'development' => env('MODULES_DEVELOPMENT', env('APP_DEBUG', false)),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Modules
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, the loaded module collection is cached for performance.
+    | Disabled by default to keep discovery deterministic.
+    |
+    */
+
+    'cache' => env('MODULES_CACHE', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cache Key / TTL
+    |--------------------------------------------------------------------------
+    */
+
+    'cache_key' => 'app.modules',
+
+    'cache_ttl' => 3600,
+
+];

--- a/database/migrations/2026_02_03_000000_create_modules_table.php
+++ b/database/migrations/2026_02_03_000000_create_modules_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('modules', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('version')->nullable();
+            $table->text('description')->nullable();
+            $table->boolean('enabled')->default(false);
+            $table->json('dependencies')->nullable();
+            $table->json('config')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('modules');
+    }
+};

--- a/tests/Feature/ModuleDiscoveryTest.php
+++ b/tests/Feature/ModuleDiscoveryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\Module;
+use App\Modules\Events\ModuleDisabled;
+use App\Modules\Events\ModuleEnabled;
+use App\Modules\Events\ModuleInstalled;
+use App\Modules\Events\ModuleUninstalled;
+use App\Modules\ModuleManager;
+use Illuminate\Support\Facades\Event;
+
+it('discovers the BlogModule fixture from disk', function () {
+    $manager = new ModuleManager();
+
+    expect($manager->has('BlogModule'))->toBeTrue()
+        ->and($manager->get('BlogModule'))->not->toBeNull()
+        ->and($manager->getAllModulesInfo())->not->toBeEmpty();
+});
+
+it('does not treat framework subfolders (Contracts/Events/Traits) as modules', function () {
+    $keys = (new ModuleManager())->all()->keys()->all();
+
+    expect($keys)->toBe(['BlogModule']);
+});
+
+it('persists enable then disable state to the modules table', function () {
+    (new ModuleManager())->enable('BlogModule');
+    expect(Module::findByName('BlogModule'))->not->toBeNull()
+        ->and(Module::findByName('BlogModule')->enabled)->toBeTrue();
+
+    (new ModuleManager())->disable('BlogModule');
+    expect(Module::findByName('BlogModule')->enabled)->toBeFalse();
+});
+
+it('dispatches lifecycle events on enable and disable', function () {
+    Event::fake([ModuleEnabled::class, ModuleDisabled::class]);
+
+    $manager = new ModuleManager();
+    $manager->enable('BlogModule');
+    $manager->disable('BlogModule');
+
+    Event::assertDispatched(ModuleEnabled::class);
+    Event::assertDispatched(ModuleDisabled::class);
+});
+
+it('dispatches install and uninstall lifecycle events', function () {
+    Event::fake([ModuleInstalled::class, ModuleUninstalled::class]);
+
+    $manager = new ModuleManager();
+    $manager->install('BlogModule');
+    $manager->uninstall('BlogModule');
+
+    Event::assertDispatched(ModuleInstalled::class);
+    Event::assertDispatched(ModuleUninstalled::class);
+});

--- a/tests/Feature/ModuleResourceTest.php
+++ b/tests/Feature/ModuleResourceTest.php
@@ -19,5 +19,9 @@ it('renders the modules list (non-Eloquent data source)', function () {
     Filament::setCurrentPanel(Filament::getPanel('admin'));
     Filament::setTenant($team);
 
-    Livewire::test(ListModules::class)->assertOk();
+    // Must actually list the discovered module — a bare assertOk() passed while the
+    // table was silently empty (the loader never found BlogModule).
+    Livewire::test(ListModules::class)
+        ->assertOk()
+        ->assertSee('BlogModule');
 });

--- a/tests/Feature/ModuleResourceTest.php
+++ b/tests/Feature/ModuleResourceTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Filament\Resources\ModuleResource\Pages\ListModules;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('renders the modules list (non-Eloquent data source)', function () {
+    $team = Team::factory()->create();
+    $user = User::factory()->create(['current_team_id' => $team->id]);
+
+    Gate::before(fn () => true);
+    $this->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($team);
+
+    Livewire::test(ListModules::class)->assertOk();
+});

--- a/tests/Unit/ModuleConfigurableTest.php
+++ b/tests/Unit/ModuleConfigurableTest.php
@@ -1,0 +1,358 @@
+<?php
+
+use App\Modules\Contracts\ModuleInterface;
+use App\Modules\Traits\Configurable;
+use Illuminate\Support\Facades\Config;
+
+beforeEach(function () {
+    Config::set('testmodule', [
+        'key1' => 'value1',
+        'key2' => 'value2',
+        'nested' => [
+            'key' => 'nested_value',
+        ],
+    ]);
+});
+
+it('can get configuration values', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use Configurable;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $value = $module->config('key1');
+    expect($value)->toBe('value1');
+});
+
+it('returns default when key not found', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use Configurable;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $value = $module->config('nonexistent', 'default_value');
+    expect($value)->toBe('default_value');
+});
+
+it('can set configuration values', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use Configurable;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $module->setConfig('new_key', 'new_value');
+    $value = $module->config('new_key');
+    expect($value)->toBe('new_value');
+});
+
+it('can check if configuration exists', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use Configurable;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    expect($module->hasConfig('key1'))->toBeTrue();
+    expect($module->hasConfig('nonexistent'))->toBeFalse();
+});
+
+it('can get all configuration', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use Configurable;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $allConfig = $module->getAllConfig();
+    expect($allConfig)->toBeArray();
+    expect($allConfig)->toHaveKey('key1');
+    expect($allConfig)->toHaveKey('key2');
+    expect($allConfig['key1'])->toBe('value1');
+});
+
+it('can merge configuration', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use Configurable;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $module->mergeConfig(['key3' => 'value3', 'key4' => 'value4']);
+
+    expect($module->config('key3'))->toBe('value3');
+    expect($module->config('key4'))->toBe('value4');
+    expect($module->config('key1'))->toBe('value1'); // Original should still exist
+});
+
+it('handles nested configuration keys', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use Configurable;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $value = $module->config('nested.key');
+    expect($value)->toBe('nested_value');
+});

--- a/tests/Unit/ModuleHooksTest.php
+++ b/tests/Unit/ModuleHooksTest.php
@@ -1,0 +1,385 @@
+<?php
+
+use App\Modules\Contracts\ModuleInterface;
+use App\Modules\Traits\HasModuleHooks;
+
+it('can register and execute hooks', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use HasModuleHooks;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $called = false;
+    $module->registerHook('test_hook', function () use (&$called) {
+        $called = true;
+    });
+
+    expect($module->hasHook('test_hook'))->toBeTrue();
+
+    $module->executeHook('test_hook');
+    expect($called)->toBeTrue();
+});
+
+it('executes hooks in priority order', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use HasModuleHooks;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $order = [];
+
+    $module->registerHook('priority_test', function () use (&$order) {
+        $order[] = 'second';
+    }, priority: 20);
+
+    $module->registerHook('priority_test', function () use (&$order) {
+        $order[] = 'first';
+    }, priority: 10);
+
+    $module->registerHook('priority_test', function () use (&$order) {
+        $order[] = 'third';
+    }, priority: 30);
+
+    $module->executeHook('priority_test');
+
+    expect($order)->toBe(['first', 'second', 'third']);
+});
+
+it('passes arguments to hook callbacks', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use HasModuleHooks;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $result = null;
+    $module->registerHook('with_args', function ($arg1, $arg2) use (&$result) {
+        $result = $arg1 + $arg2;
+    });
+
+    $module->executeHook('with_args', 5, 10);
+    expect($result)->toBe(15);
+});
+
+it('can clear hooks', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use HasModuleHooks;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $module->registerHook('clearable', function () {});
+    expect($module->hasHook('clearable'))->toBeTrue();
+
+    $module->clearHook('clearable');
+    expect($module->hasHook('clearable'))->toBeFalse();
+});
+
+it('returns list of registered hooks', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use HasModuleHooks;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $module->registerHook('hook1', function () {});
+    $module->registerHook('hook2', function () {});
+    $module->registerHook('hook3', function () {});
+
+    $hooks = $module->getHooks();
+    expect($hooks)->toBeArray();
+    expect($hooks)->toContain('hook1', 'hook2', 'hook3');
+});
+
+it('returns null when executing non-existent hook', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use HasModuleHooks;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $result = $module->executeHook('nonexistent');
+    expect($result)->toBeNull();
+});
+
+it('returns result from last callback', function () {
+    $module = new class() implements ModuleInterface
+    {
+        use HasModuleHooks;
+
+        public function getName(): string
+        {
+            return 'TestModule';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Test';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return true;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $module->registerHook('multi_return', function () {
+        return 'first';
+    });
+    $module->registerHook('multi_return', function () {
+        return 'second';
+    });
+    $module->registerHook('multi_return', function () {
+        return 'last';
+    });
+
+    $result = $module->executeHook('multi_return');
+    expect($result)->toBe('last');
+});

--- a/tests/Unit/ModuleManagerTest.php
+++ b/tests/Unit/ModuleManagerTest.php
@@ -443,7 +443,7 @@ it('prevents disabling modules that have enabled dependents', function () {
     $manager->disable('B');
 });
 
-it('install and uninstall enforce dependency rules', function () {
+it('install enforces dependency rules', function () {
     $manager = new ModuleManager();
 
     $m = new class() implements ModuleInterface
@@ -587,16 +587,11 @@ it('install and uninstall enforce dependency rules', function () {
     $manager->register($dep);
     $manager->register($mWithDep);
 
-    // install should throw because Dep isn't enabled
-    $this->expectException(Exception::class);
-    $manager->install('Mwith');
-
-    // Similarly, uninstall should throw if there are dependents enabled
-    // enable Dep and enable Mwith then try uninstalling Dep
-    $dep->enable();
-    $mWithDep->enable();
-    $this->expectException(Exception::class);
-    $manager->uninstall('Dep');
+    // install should throw because Dep isn't enabled.
+    // (uninstall's enabled-dependents guard shares hasDependents(), which is covered by
+    // the "prevents disabling modules that have enabled dependents" test above, and the
+    // real install/uninstall lifecycle + events are covered in tests/Feature/ModuleDiscoveryTest.)
+    expect(fn () => $manager->install('Mwith'))->toThrow(Exception::class);
 });
 
 it('provides module info and aggregates all modules info', function () {

--- a/tests/Unit/ModuleManagerTest.php
+++ b/tests/Unit/ModuleManagerTest.php
@@ -1,0 +1,655 @@
+<?php
+
+use App\Modules\Contracts\ModuleInterface;
+use App\Modules\ModuleManager;
+use Exception;
+
+beforeEach(function () {
+    // Nothing global needed for these pure unit tests
+});
+
+it('can register modules and expose them via all/has/get', function () {
+    $manager = new ModuleManager();
+
+    $mod = new class() implements ModuleInterface
+    {
+        public function getName(): string
+        {
+            return 'M1';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'd';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return false;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $manager->register($mod);
+
+    expect($manager->has('M1'))->toBeTrue();
+    expect($manager->get('M1'))->not->toBeNull();
+    expect($manager->all()->count())->toBeGreaterThanOrEqual(1);
+});
+
+it('filters enabled and disabled modules', function () {
+    $manager = new ModuleManager();
+
+    $enabled = new class() implements ModuleInterface
+    {
+        private $e = true;
+
+        public function getName(): string
+        {
+            return 'E';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'd';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $disabled = new class() implements ModuleInterface
+    {
+        private $e = false;
+
+        public function getName(): string
+        {
+            return 'D';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'd';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $manager->register($enabled);
+    $manager->register($disabled);
+
+    expect($manager->enabled()->contains(fn ($m) => $m->getName() === 'E'))->toBeTrue();
+    expect($manager->disabled()->contains(fn ($m) => $m->getName() === 'D'))->toBeTrue();
+});
+
+it('enables a module and returns true even if persisting fails', function () {
+    $manager = new ModuleManager();
+
+    $m = new class() implements ModuleInterface
+    {
+        private $e = false;
+
+        public function getName(): string
+        {
+            return 'P';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'd';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $manager->register($m);
+
+    $res = $manager->enable('P');
+    expect($res)->toBeTrue();
+    expect($manager->get('P')->isEnabled())->toBeTrue();
+});
+
+it('throws when enabling a module with unmet dependencies', function () {
+    $manager = new ModuleManager();
+
+    $a = new class() implements ModuleInterface
+    {
+        private $e = false;
+
+        public function getName(): string
+        {
+            return 'A';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'A';
+        }
+
+        public function getDependencies(): array
+        {
+            return ['B'];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $b = new class() implements ModuleInterface
+    {
+        private $e = false;
+
+        public function getName(): string
+        {
+            return 'B';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'B';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $manager->register($a);
+    $manager->register($b);
+
+    $this->expectException(Exception::class);
+    $manager->enable('A');
+});
+
+it('prevents disabling modules that have enabled dependents', function () {
+    $manager = new ModuleManager();
+
+    $b = new class() implements ModuleInterface
+    {
+        private $e = true;
+
+        public function getName(): string
+        {
+            return 'B';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'B';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $a = new class() implements ModuleInterface
+    {
+        private $e = true;
+
+        public function getName(): string
+        {
+            return 'A';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'A';
+        }
+
+        public function getDependencies(): array
+        {
+            return ['B'];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $manager->register($b);
+    $manager->register($a);
+
+    // A depends on B and both are enabled; disabling B should throw
+    $this->expectException(Exception::class);
+    $manager->disable('B');
+});
+
+it('install and uninstall enforce dependency rules', function () {
+    $manager = new ModuleManager();
+
+    $m = new class() implements ModuleInterface
+    {
+        public function getName(): string
+        {
+            return 'I';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'I';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return false;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void
+        { /* perform install */
+        }
+
+        public function uninstall(): void
+        { /* perform uninstall */
+        }
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $dep = new class() implements ModuleInterface
+    {
+        private $e = false;
+
+        public function getName(): string
+        {
+            return 'Dep';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'Dep';
+        }
+
+        public function getDependencies(): array
+        {
+            return [];
+        }
+
+        public function isEnabled(): bool
+        {
+            return $this->e;
+        }
+
+        public function enable(): void
+        {
+            $this->e = true;
+        }
+
+        public function disable(): void
+        {
+            $this->e = false;
+        }
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $mWithDep = new class() implements ModuleInterface
+    {
+        public function getName(): string
+        {
+            return 'Mwith';
+        }
+
+        public function getVersion(): string
+        {
+            return '1.0';
+        }
+
+        public function getDescription(): string
+        {
+            return 'has dep';
+        }
+
+        public function getDependencies(): array
+        {
+            return ['Dep'];
+        }
+
+        public function isEnabled(): bool
+        {
+            return false;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return [];
+        }
+    };
+
+    $manager->register($m);
+    expect($manager->install('I'))->toBeTrue();
+
+    $manager->register($dep);
+    $manager->register($mWithDep);
+
+    // install should throw because Dep isn't enabled
+    $this->expectException(Exception::class);
+    $manager->install('Mwith');
+
+    // Similarly, uninstall should throw if there are dependents enabled
+    // enable Dep and enable Mwith then try uninstalling Dep
+    $dep->enable();
+    $mWithDep->enable();
+    $this->expectException(Exception::class);
+    $manager->uninstall('Dep');
+});
+
+it('provides module info and aggregates all modules info', function () {
+    $manager = new ModuleManager();
+
+    $m = new class() implements ModuleInterface
+    {
+        public function getName(): string
+        {
+            return 'Info';
+        }
+
+        public function getVersion(): string
+        {
+            return '9.9';
+        }
+
+        public function getDescription(): string
+        {
+            return 'desc';
+        }
+
+        public function getDependencies(): array
+        {
+            return ['X'];
+        }
+
+        public function isEnabled(): bool
+        {
+            return false;
+        }
+
+        public function enable(): void {}
+
+        public function disable(): void {}
+
+        public function install(): void {}
+
+        public function uninstall(): void {}
+
+        public function getConfig(): array
+        {
+            return ['a' => 'b'];
+        }
+    };
+
+    $manager->register($m);
+
+    $info = $manager->getModuleInfo('Info');
+    expect($info['name'])->toBe('Info');
+    expect($info['version'])->toBe('9.9');
+    expect($info['dependencies'])->toBeArray();
+
+    $all = $manager->getAllModulesInfo();
+    expect(array_column($all, 'name'))->toContain('Info');
+});

--- a/tests/Unit/ModuleModelTest.php
+++ b/tests/Unit/ModuleModelTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\Module;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('casts fields correctly', function () {
+    $m = Module::create([
+        'name' => 'CastModule',
+        'version' => '1.2',
+        'description' => 'x',
+        'enabled' => true,
+        'dependencies' => ['A', 'B'],
+        'config' => ['k' => 'v'],
+    ]);
+
+    $found = Module::findByName('CastModule');
+    expect($found)->not->toBeNull();
+    expect($found->enabled)->toBeTrue();
+    expect(is_array($found->dependencies))->toBeTrue();
+    expect($found->config['k'])->toBe('v');
+});


### PR DESCRIPTION
## Phase 4 — Custom module system (`app/Modules/`)

Stacks on #577 (Phase 3). Base `phase-3-i18n`.

Ported from `feat/edit-profile-clear-signal` onto the clean base, TDD. Single module system only — `internachi/modular` was removed in Phase 0.

### Included
- `modules` table + `App\Models\Module` registry
- `ModuleManager` — discovery (scan `app/Modules/*` for `module.json`) + lifecycle (install/enable/disable/uninstall) with dependency + dependents enforcement
- `BaseModule` + `ModuleInterface` + `Configurable`/`HasModuleHooks` traits + 4 lifecycle events; `ModuleServiceProvider` (registered)
- Filament `ModuleResource` relocated to `App\Filament\Resources` (admin UI)
- Thin `BlogModule` (`BlogModule.php` + `module.json`) — a registry fixture

### Decisions (per analysis critique)
- **Stripped the internachi/modular path** from `ModuleManager`; **cut `ExternalModuleLoader`** (vendor-scan, zero consumers — YAGNI) + its skip-gated test + `config/modular.php`
- **Thin BlogModule** — skipped the demo controller/routes/views/service (views `@extend` a non-existent layout → would 500; nothing consumes module routes yet)
- `isScopedToTenant()` **not** added — `ModuleResource` `$model = null`, so the tenant panel never model-scopes (verified: renders 200 under tenancy)

### ⚠️ Adversarial review caught a critical bug (fixed in this PR)
The loader resolved the module class as `{dir}{dir}Module` (doubled suffix), so **no module ever loaded** — empty registry, empty admin table, no events. CI was green only because tests used anonymous fakes and the resource test asserted bare `ok()` on an empty table. Fixed: candidate-class resolution (`{dir}` or `{dir}Module`) + `module.json` gate (also stops `Contracts/Events/Traits` being scanned). Added `ModuleDiscoveryTest` (real disk discovery + DB persistence + all 4 events) and a record assertion to `ModuleResourceTest` so it can't regress green.

### Verification
- phpstan **L9** clean · pint clean · **pest 108 passed / 0 failed**
