### PR TITLE
Phase 6: private encrypted messaging (REST API)

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,9 @@
 
 namespace App\Http\Controllers;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
 abstract class Controller
 {
-    //
+    use AuthorizesRequests;
 }

--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Validation\ValidationException;
+
+class MessageController extends Controller
+{
+    /**
+     * List the authenticated user's conversations, newest first.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+
+        $conversations = Message::query()
+            ->where('sender_id', $user->id)
+            ->orWhere('recipient_id', $user->id)
+            ->with(['sender', 'recipient'])
+            ->orderByDesc('created_at')
+            ->get()
+            ->groupBy(fn (Message $message): int => $message->sender_id === $user->id
+                ? $message->recipient_id
+                : $message->sender_id)
+            ->map(function (Collection $messages, int|string $userId) use ($user): array {
+                /** @var Message $last */
+                $last = $messages->first();
+                // Decrypt the preview body so the conversation list isn't ciphertext.
+                $last->body = Crypt::decryptString($last->body);
+
+                return [
+                    'user' => User::find((int) $userId),
+                    'last_message' => $last,
+                    'unread_count' => $messages
+                        ->where('recipient_id', $user->id)
+                        ->whereNull('read_at')
+                        ->count(),
+                ];
+            })
+            ->values();
+
+        return response()->json($conversations);
+    }
+
+    /**
+     * Show the conversation between the authenticated user and another user,
+     * marking the other user's messages as read.
+     */
+    public function show(Request $request, User $user): JsonResponse
+    {
+        /** @var User $authUser */
+        $authUser = $request->user();
+
+        $messages = Message::between($authUser->id, $user->id)
+            ->with(['sender', 'recipient'])
+            ->orderBy('created_at')
+            ->get()
+            ->map(function (Message $message): Message {
+                $message->body = Crypt::decryptString($message->body);
+
+                return $message;
+            });
+
+        Message::query()
+            ->where('sender_id', $user->id)
+            ->where('recipient_id', $authUser->id)
+            ->whereNull('read_at')
+            ->update(['read_at' => now()]);
+
+        return response()->json([
+            'messages' => $messages,
+            'user' => $user,
+        ]);
+    }
+
+    /**
+     * Store a new message, encrypting the body at rest.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'recipient_id' => 'required|exists:users,id',
+            'body' => 'required|string|max:5000',
+        ]);
+
+        /** @var User $authUser */
+        $authUser = $request->user();
+
+        if ($authUser->id === (int) $validated['recipient_id']) {
+            throw ValidationException::withMessages([
+                'recipient_id' => ['You cannot send messages to yourself.'],
+            ]);
+        }
+
+        $message = Message::create([
+            'sender_id' => $authUser->id,
+            'recipient_id' => (int) $validated['recipient_id'],
+            'body' => Crypt::encryptString($validated['body']),
+        ]);
+
+        $message->load(['sender', 'recipient']);
+        // Echo the plaintext back for immediate display; storage stays encrypted.
+        $message->body = $validated['body'];
+
+        return response()->json([
+            'message' => $message,
+            'success' => true,
+        ], 201);
+    }
+
+    /**
+     * Mark a message as read (recipient only).
+     */
+    public function markAsRead(Request $request, Message $message): JsonResponse
+    {
+        $this->authorize('view', $message);
+
+        if ($request->user()?->id !== $message->recipient_id) {
+            return response()->json(['error' => 'Unauthorized'], 403);
+        }
+
+        $message->markAsRead();
+
+        return response()->json([
+            'success' => true,
+            'message' => $message,
+        ]);
+    }
+
+    /**
+     * Delete a message the authenticated user sent or received.
+     */
+    public function destroy(Message $message): JsonResponse
+    {
+        $this->authorize('delete', $message);
+
+        $message->delete();
+
+        return response()->json([
+            'success' => true,
+            'message' => 'Message deleted successfully',
+        ]);
+    }
+
+    /**
+     * List users available to message (everyone but the authenticated user).
+     */
+    public function users(Request $request): JsonResponse
+    {
+        $users = User::query()
+            ->whereKeyNot($request->user()?->getKey())
+            ->select('id', 'name', 'profile_photo_path')
+            ->orderBy('name')
+            ->get();
+
+        return response()->json($users);
+    }
+
+    /**
+     * Unread message count for the authenticated user.
+     */
+    public function unreadCount(Request $request): JsonResponse
+    {
+        $count = Message::query()
+            ->where('recipient_id', $request->user()?->id)
+            ->whereNull('read_at')
+            ->count();
+
+        return response()->json(['count' => $count]);
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\MessageFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $sender_id
+ * @property int $recipient_id
+ * @property string $body
+ * @property Carbon|null $read_at
+ */
+class Message extends Model
+{
+    /** @use HasFactory<MessageFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'sender_id',
+        'recipient_id',
+        'body',
+        'read_at',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'read_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function sender(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function recipient(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'recipient_id');
+    }
+
+    /**
+     * Mark the message as read.
+     */
+    public function markAsRead(): void
+    {
+        $this->update(['read_at' => now()]);
+    }
+
+    /**
+     * Determine if the message has been read.
+     */
+    public function isRead(): bool
+    {
+        return $this->read_at !== null;
+    }
+
+    /**
+     * Scope a query to messages exchanged between two users (either direction).
+     *
+     * @param  Builder<Message>  $query
+     * @return Builder<Message>
+     */
+    public function scopeBetween(Builder $query, int $userId1, int $userId2): Builder
+    {
+        return $query->where(function (Builder $q) use ($userId1, $userId2) {
+            $q->where('sender_id', $userId1)->where('recipient_id', $userId2);
+        })->orWhere(function (Builder $q) use ($userId1, $userId2) {
+            $q->where('sender_id', $userId2)->where('recipient_id', $userId1);
+        });
+    }
+
+    /**
+     * Scope a query to only include unread messages.
+     *
+     * @param  Builder<Message>  $query
+     * @return Builder<Message>
+     */
+    public function scopeUnread(Builder $query): Builder
+    {
+        return $query->whereNull('read_at');
+    }
+}

--- a/app/Policies/MessagePolicy.php
+++ b/app/Policies/MessagePolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Message;
+use App\Models\User;
+
+class MessagePolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the message.
+     */
+    public function view(User $user, Message $message): bool
+    {
+        return $user->id === $message->sender_id || $user->id === $message->recipient_id;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can update the message.
+     */
+    public function update(User $user, Message $message): bool
+    {
+        return $user->id === $message->sender_id;
+    }
+
+    /**
+     * Determine whether the user can delete the message.
+     */
+    public function delete(User $user, Message $message): bool
+    {
+        return $user->id === $message->sender_id || $user->id === $message->recipient_id;
+    }
+}

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Crypt;
+
+/**
+ * @extends Factory<Message>
+ */
+class MessageFactory extends Factory
+{
+    protected $model = Message::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'sender_id' => User::factory(),
+            'recipient_id' => User::factory(),
+            'body' => Crypt::encryptString(fake()->sentence()),
+            'read_at' => null,
+        ];
+    }
+
+    /**
+     * Indicate that the message has been read.
+     */
+    public function read(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'read_at' => now(),
+        ]);
+    }
+
+    /**
+     * Indicate that the message is unread.
+     */
+    public function unread(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'read_at' => null,
+        ]);
+    }
+}

--- a/database/migrations/2026_02_14_122604_create_messages_table.php
+++ b/database/migrations/2026_02_14_122604_create_messages_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('sender_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('recipient_id')->constrained('users')->cascadeOnDelete();
+            $table->text('body');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['sender_id', 'recipient_id']);
+            $table->index('recipient_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\SearchController;
+use App\Http\Controllers\MessageController;
 use Illuminate\Support\Facades\Route;
 
 // Search API routes
@@ -9,4 +10,15 @@ Route::prefix('search')->name('search.')->middleware('throttle:60,1')->group(fun
     Route::get('/posts', [SearchController::class, 'posts'])->name('posts');
     Route::get('/groups', [SearchController::class, 'groups'])->name('groups');
     Route::get('/all', [SearchController::class, 'all'])->name('all');
+});
+
+// Private messaging (literal segments must precede the {user}/{message} wildcards).
+Route::middleware('auth:sanctum')->prefix('messages')->name('messages.')->group(function () {
+    Route::get('/', [MessageController::class, 'index'])->name('index');
+    Route::get('/users', [MessageController::class, 'users'])->name('users');
+    Route::get('/unread-count', [MessageController::class, 'unreadCount'])->name('unread-count');
+    Route::get('/{user}', [MessageController::class, 'show'])->name('show');
+    Route::post('/', [MessageController::class, 'store'])->name('store');
+    Route::patch('/{message}/read', [MessageController::class, 'markAsRead'])->name('read');
+    Route::delete('/{message}', [MessageController::class, 'destroy'])->name('destroy');
 });

--- a/tests/Feature/MessageApiTest.php
+++ b/tests/Feature/MessageApiTest.php
@@ -1,0 +1,279 @@
+<?php
+
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Support\Facades\Crypt;
+
+it('can send a message via API', function () {
+    $sender = User::factory()->create();
+    $recipient = User::factory()->create();
+
+    $response = $this->actingAs($sender, 'sanctum')
+        ->postJson('/api/messages', [
+            'recipient_id' => $recipient->id,
+            'body' => 'Test message',
+        ]);
+
+    $response->assertStatus(201)
+        ->assertJsonStructure([
+            'message' => ['id', 'sender_id', 'recipient_id', 'body', 'created_at'],
+            'success',
+        ]);
+
+    expect(Message::count())->toBe(1);
+    // Body must be stored encrypted, never as plaintext.
+    expect(Crypt::decryptString(Message::first()->body))->toBe('Test message');
+});
+
+it('prevents sending messages to self', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->postJson('/api/messages', [
+            'recipient_id' => $user->id,
+            'body' => 'Message to myself',
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['recipient_id']);
+});
+
+it('requires authentication to send messages', function () {
+    $recipient = User::factory()->create();
+
+    $response = $this->postJson('/api/messages', [
+        'recipient_id' => $recipient->id,
+        'body' => 'Test message',
+    ]);
+
+    $response->assertStatus(401);
+});
+
+it('can retrieve conversation between two users', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    Message::factory()->create([
+        'sender_id' => $user1->id,
+        'recipient_id' => $user2->id,
+        'body' => Crypt::encryptString('Message 1'),
+    ]);
+
+    Message::factory()->create([
+        'sender_id' => $user2->id,
+        'recipient_id' => $user1->id,
+        'body' => Crypt::encryptString('Message 2'),
+    ]);
+
+    $response = $this->actingAs($user1, 'sanctum')
+        ->getJson("/api/messages/{$user2->id}");
+
+    $response->assertStatus(200)
+        ->assertJsonStructure([
+            'messages' => [
+                '*' => ['id', 'sender_id', 'recipient_id', 'body', 'created_at'],
+            ],
+            'user',
+        ]);
+
+    expect($response->json('messages'))->toHaveCount(2);
+    // Bodies are decrypted for display.
+    expect($response->json('messages.0.body'))->toBe('Message 1');
+});
+
+it('marks the other user messages as read when opening a conversation', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    $incoming = Message::factory()->unread()->create([
+        'sender_id' => $user2->id,
+        'recipient_id' => $user1->id,
+    ]);
+
+    $this->actingAs($user1, 'sanctum')
+        ->getJson("/api/messages/{$user2->id}")
+        ->assertStatus(200);
+
+    expect($incoming->fresh()->isRead())->toBeTrue();
+});
+
+it('does not leak recipient email in the users list', function () {
+    $user = User::factory()->create();
+    User::factory()->create(['email' => 'secret@example.com']);
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->getJson('/api/messages/users');
+
+    $response->assertStatus(200)
+        ->assertJsonMissing(['email' => 'secret@example.com']);
+});
+
+it('lists conversations with a decrypted preview and unread count', function () {
+    $me = User::factory()->create();
+    $other = User::factory()->create();
+
+    Message::factory()->create([
+        'sender_id' => $me->id,
+        'recipient_id' => $other->id,
+        'body' => Crypt::encryptString('older'),
+        'created_at' => now()->subMinute(),
+    ]);
+    Message::factory()->unread()->create([
+        'sender_id' => $other->id,
+        'recipient_id' => $me->id,
+        'body' => Crypt::encryptString('newest'),
+        'created_at' => now(),
+    ]);
+
+    $response = $this->actingAs($me, 'sanctum')->getJson('/api/messages');
+
+    $response->assertStatus(200)
+        ->assertJsonCount(1)
+        // Preview must be plaintext, not ciphertext.
+        ->assertJsonPath('0.last_message.body', 'newest')
+        ->assertJsonPath('0.unread_count', 1);
+});
+
+it('forbids a non-participant from reading a conversation', function () {
+    $a = User::factory()->create();
+    $b = User::factory()->create();
+    $outsider = User::factory()->create();
+
+    Message::factory()->create(['sender_id' => $a->id, 'recipient_id' => $b->id]);
+
+    // Outsider asking for their thread with $a simply sees an empty thread —
+    // never $a<->$b messages.
+    $response = $this->actingAs($outsider, 'sanctum')->getJson("/api/messages/{$a->id}");
+
+    $response->assertStatus(200);
+    expect($response->json('messages'))->toBeEmpty();
+});
+
+it('forbids deleting a message you are not party to', function () {
+    $sender = User::factory()->create();
+    $recipient = User::factory()->create();
+    $outsider = User::factory()->create();
+
+    $message = Message::factory()->create([
+        'sender_id' => $sender->id,
+        'recipient_id' => $recipient->id,
+    ]);
+
+    $this->actingAs($outsider, 'sanctum')
+        ->deleteJson("/api/messages/{$message->id}")
+        ->assertStatus(403);
+
+    expect(Message::find($message->id))->not->toBeNull();
+});
+
+it('can mark a message as read', function () {
+    $sender = User::factory()->create();
+    $recipient = User::factory()->create();
+
+    $message = Message::factory()->create([
+        'sender_id' => $sender->id,
+        'recipient_id' => $recipient->id,
+        'read_at' => null,
+    ]);
+
+    $response = $this->actingAs($recipient, 'sanctum')
+        ->patchJson("/api/messages/{$message->id}/read");
+
+    $response->assertStatus(200);
+
+    expect($message->fresh()->isRead())->toBeTrue();
+});
+
+it('prevents unauthorized users from viewing messages', function () {
+    $sender = User::factory()->create();
+    $recipient = User::factory()->create();
+    $otherUser = User::factory()->create();
+
+    $message = Message::factory()->create([
+        'sender_id' => $sender->id,
+        'recipient_id' => $recipient->id,
+    ]);
+
+    $response = $this->actingAs($otherUser, 'sanctum')
+        ->patchJson("/api/messages/{$message->id}/read");
+
+    $response->assertStatus(403);
+});
+
+it('can delete own messages', function () {
+    $sender = User::factory()->create();
+    $recipient = User::factory()->create();
+
+    $message = Message::factory()->create([
+        'sender_id' => $sender->id,
+        'recipient_id' => $recipient->id,
+    ]);
+
+    $response = $this->actingAs($sender, 'sanctum')
+        ->deleteJson("/api/messages/{$message->id}");
+
+    $response->assertStatus(200);
+
+    expect(Message::find($message->id))->toBeNull();
+});
+
+it('can get list of users to message', function () {
+    $user = User::factory()->create();
+    User::factory()->count(5)->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->getJson('/api/messages/users');
+
+    $response->assertStatus(200);
+    expect($response->json())->toHaveCount(5); // Excludes the authenticated user.
+});
+
+it('can get unread message count', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    Message::factory()->count(3)->create([
+        'sender_id' => $user2->id,
+        'recipient_id' => $user1->id,
+        'read_at' => null,
+    ]);
+
+    Message::factory()->count(2)->create([
+        'sender_id' => $user2->id,
+        'recipient_id' => $user1->id,
+        'read_at' => now(),
+    ]);
+
+    $response = $this->actingAs($user1, 'sanctum')
+        ->getJson('/api/messages/unread-count');
+
+    $response->assertStatus(200)
+        ->assertJson(['count' => 3]);
+});
+
+it('validates message body is required', function () {
+    $user = User::factory()->create();
+    $recipient = User::factory()->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->postJson('/api/messages', [
+            'recipient_id' => $recipient->id,
+            'body' => '',
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['body']);
+});
+
+it('validates recipient exists', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user, 'sanctum')
+        ->postJson('/api/messages', [
+            'recipient_id' => 99999,
+            'body' => 'Test message',
+        ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['recipient_id']);
+});

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use App\Models\Message;
+use App\Models\User;
+use Illuminate\Support\Facades\Crypt;
+
+it('can create a message between users', function () {
+    $sender = User::factory()->create();
+    $recipient = User::factory()->create();
+
+    $messageBody = 'Hello, this is a test message';
+    $encryptedBody = Crypt::encryptString($messageBody);
+
+    $message = Message::create([
+        'sender_id' => $sender->id,
+        'recipient_id' => $recipient->id,
+        'body' => $encryptedBody,
+    ]);
+
+    expect($message)->toBeInstanceOf(Message::class);
+    expect($message->sender_id)->toBe($sender->id);
+    expect($message->recipient_id)->toBe($recipient->id);
+    expect(Crypt::decryptString($message->body))->toBe($messageBody);
+    expect($message->isRead())->toBeFalse();
+});
+
+it('can mark a message as read', function () {
+    $message = Message::factory()->create([
+        'read_at' => null,
+    ]);
+
+    expect($message->isRead())->toBeFalse();
+
+    $message->markAsRead();
+
+    expect($message->fresh()->isRead())->toBeTrue();
+});
+
+it('can get messages between two users', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+    $user3 = User::factory()->create();
+
+    Message::factory()->create([
+        'sender_id' => $user1->id,
+        'recipient_id' => $user2->id,
+    ]);
+
+    Message::factory()->create([
+        'sender_id' => $user2->id,
+        'recipient_id' => $user1->id,
+    ]);
+
+    // From user3 — must not be included.
+    Message::factory()->create([
+        'sender_id' => $user3->id,
+        'recipient_id' => $user1->id,
+    ]);
+
+    $messagesBetween = Message::between($user1->id, $user2->id)->get();
+
+    expect($messagesBetween)->toHaveCount(2);
+});
+
+it('can scope unread messages', function () {
+    $user1 = User::factory()->create();
+    $user2 = User::factory()->create();
+
+    Message::factory()->create([
+        'sender_id' => $user1->id,
+        'recipient_id' => $user2->id,
+        'read_at' => null,
+    ]);
+
+    Message::factory()->create([
+        'sender_id' => $user1->id,
+        'recipient_id' => $user2->id,
+        'read_at' => now(),
+    ]);
+
+    $unreadMessages = Message::where('recipient_id', $user2->id)
+        ->unread()
+        ->get();
+
+    expect($unreadMessages)->toHaveCount(1);
+});
+
+it('has sender and recipient relationships', function () {
+    $sender = User::factory()->create(['name' => 'John Doe']);
+    $recipient = User::factory()->create(['name' => 'Jane Smith']);
+
+    $message = Message::factory()->create([
+        'sender_id' => $sender->id,
+        'recipient_id' => $recipient->id,
+    ]);
+
+    expect($message->sender->name)->toBe('John Doe');
+    expect($message->recipient->name)->toBe('Jane Smith');
+});


### PR DESCRIPTION
## Phase 6 — Private Messaging

Ports the 1:1 messaging subsystem onto the fresh skeleton.

- `Message` model (sender/recipient, `between()`/`unread()` scopes, read tracking) + migration + factory.
- `MessageController` — conversations index, per-user thread, send, mark-read, delete, user list, unread count. **Bodies encrypted at rest** (`Crypt`).
- `MessagePolicy` (participant-only view/delete, sender-only update), auto-discovered; `AuthorizesRequests` added to the base `Controller`.
- Routes under `auth:sanctum` (literal segments ordered before `{user}`/`{message}` wildcards).

### L9 hardening + adversarial-review fixes
- **`index()` was returning the `last_message` preview as ciphertext** (no `Crypt::decryptString`, unlike `show()`/`store()`) and no test hit `index`. Fixed + added a test asserting plaintext preview and `unread_count`.
- `users()` no longer selects `email`; `User` globally hides `email`/`email_verified_at` (Phase 5) so no endpoint leaks PII. Added negative tests: non-participant can't read a thread or delete a message.

### Skipped (YAGNI)
Blade chat views + web UI routes (standalone views extend a missing layout), `MESSAGING.md` docs, and any broadcast/real-time event (source had none). Add when a real chat page ships.

### Verification
- Pest: 196 passed, 12 skipped, 0 failed
- PHPStan level 9: 0 errors
- Pint: clean

Stacked on `chore/fresh-skeleton`.