### PR TITLE
Phase 7: extras integration (activitylog, backup schedule, admin-gated dashboards)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ rr
 composer.phar
 .idea
 .rr.yaml
+
+# stray sqlite artifact from artisan/tinker runs
+/boilerplate-laravel

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -8,11 +8,23 @@ use Laravel\Jetstream\Events\TeamCreated;
 use Laravel\Jetstream\Events\TeamDeleted;
 use Laravel\Jetstream\Events\TeamUpdated;
 use Laravel\Jetstream\Team as JetstreamTeam;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 
 class Team extends JetstreamTeam
 {
     /** @use HasFactory<TeamFactory> */
     use HasFactory;
+
+    use LogsActivity;
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'personal_team', 'user_id'])
+            ->logOnlyDirty()
+            ->dontLogEmptyChanges();
+    }
 
     /**
      * The attributes that are mass assignable.

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -15,12 +15,15 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 use JoelButcher\Socialstream\HasConnectedAccounts;
 use JoelButcher\Socialstream\SetsProfilePhotoFromUrl;
 use Laravel\Fortify\TwoFactorAuthenticatable;
 use Laravel\Jetstream\HasProfilePhoto;
 use Laravel\Jetstream\HasTeams;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Activitylog\Models\Concerns\LogsActivity;
+use Spatie\Activitylog\Support\LogOptions;
 use Spatie\Permission\Traits\HasRoles;
 
 /**
@@ -44,6 +47,7 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
         // scopes via the team_id column + DefaultTeamResolver, not this relation.
         HasTeams::teams insteadof HasRoles;
     }
+    use LogsActivity;
     use Notifiable;
     use SetsProfilePhotoFromUrl;
     use TwoFactorAuthenticatable;
@@ -153,5 +157,36 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
             $q->where('name', 'like', "%{$search}%")
                 ->orWhere('email', 'like', "%{$search}%");
         });
+    }
+
+    /**
+     * Only track safe profile fields — never password / 2FA / tokens.
+     */
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly(['name', 'email', 'locale', 'theme_preference'])
+            ->logOnlyDirty()
+            ->dontLogEmptyChanges();
+    }
+
+    /**
+     * Admin = super_admin in any team, or an allowlisted email. Used to gate the
+     * Telescope/Pulse dashboards. The role check queries the pivot directly because
+     * Spatie's hasRole() is bound to the active team context, which is unset on the
+     * plain web requests those dashboards serve.
+     */
+    public function isAdmin(): bool
+    {
+        if (in_array($this->email, (array) config('app.admin_emails', []), true)) {
+            return true;
+        }
+
+        return DB::table('model_has_roles')
+            ->join('roles', 'roles.id', '=', 'model_has_roles.role_id')
+            ->where('model_has_roles.model_id', $this->getKey())
+            ->where('model_has_roles.model_type', $this->getMorphClass())
+            ->where('roles.name', 'super_admin')
+            ->exists();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // Gate the Pulse dashboard to admins (Telescope has its own gate).
+        Gate::define('viewPulse', fn (User $user) => $user->isAdmin());
     }
 }

--- a/app/Providers/TelescopeServiceProvider.php
+++ b/app/Providers/TelescopeServiceProvider.php
@@ -57,9 +57,7 @@ class TelescopeServiceProvider extends TelescopeApplicationServiceProvider
     protected function gate(): void
     {
         Gate::define('viewTelescope', function (User $user) {
-            return in_array($user->email, [
-                //
-            ]);
+            return $user->isAdmin();
         });
     }
 }

--- a/config/app.php
+++ b/config/app.php
@@ -17,6 +17,18 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Admin Emails
+    |--------------------------------------------------------------------------
+    |
+    | Comma-separated emails granted admin access (e.g. the Telescope / Pulse
+    | dashboards) in addition to any super_admin role. See User::isAdmin().
+    |
+    */
+
+    'admin_emails' => array_filter(array_map('trim', explode(',', (string) env('ADMIN_EMAILS', '')))),
+
+    /*
+    |--------------------------------------------------------------------------
     | Application Environment
     |--------------------------------------------------------------------------
     |

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,7 +2,12 @@
 
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+// Nightly database backup, prune old archives first.
+Schedule::command('backup:clean')->daily()->at('01:00');
+Schedule::command('backup:run', ['--only-db'])->daily()->at('01:30');

--- a/tests/Feature/ActivityLoggingTest.php
+++ b/tests/Feature/ActivityLoggingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use Spatie\Activitylog\Models\Activity;
+
+it('logs user changes but never the password', function () {
+    $user = User::factory()->create();
+
+    $user->update(['name' => 'Renamed Person', 'password' => bcrypt('new-secret')]);
+
+    $activity = Activity::query()
+        ->where('subject_type', $user->getMorphClass())
+        ->where('subject_id', $user->id)
+        ->where('event', 'updated')
+        ->latest('id')
+        ->first();
+
+    expect($activity)->not->toBeNull();
+
+    // v5 stores the attribute diff in `attribute_changes`, not `properties`.
+    $changed = $activity->attribute_changes->get('attributes', []);
+    expect($changed)->toHaveKey('name', 'Renamed Person');
+    expect($changed)->not->toHaveKey('password');
+    expect($changed)->not->toHaveKey('remember_token');
+});
+
+it('logs team changes', function () {
+    $user = User::factory()->create();
+    $team = Team::forceCreate([
+        'user_id' => $user->id,
+        'name' => 'Original',
+        'personal_team' => false,
+    ]);
+
+    $team->update(['name' => 'Updated Team']);
+
+    $logged = Activity::query()
+        ->where('subject_type', $team->getMorphClass())
+        ->where('subject_id', $team->id)
+        ->where('event', 'updated')
+        ->exists();
+
+    expect($logged)->toBeTrue();
+});

--- a/tests/Feature/AdminAccessTest.php
+++ b/tests/Feature/AdminAccessTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+use Spatie\Permission\Models\Role;
+
+it('treats an allowlisted email as an admin', function () {
+    config(['app.admin_emails' => ['boss@example.com']]);
+
+    $admin = User::factory()->create(['email' => 'boss@example.com']);
+    $other = User::factory()->create(['email' => 'nobody@example.com']);
+
+    expect($admin->isAdmin())->toBeTrue();
+    expect($other->isAdmin())->toBeFalse();
+});
+
+it('treats a super_admin (in any team) as an admin regardless of team context', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->id]);
+
+    setPermissionsTeamId($team->id);
+    $role = Role::create(['name' => 'super_admin']);
+    $user->assignRole($role);
+
+    // Leave the team context — the gate runs on plain web requests with no active team.
+    setPermissionsTeamId(null);
+
+    expect($user->fresh()->isAdmin())->toBeTrue();
+});
+
+it('gates Telescope and Pulse to admins only', function () {
+    config(['app.admin_emails' => ['boss@example.com']]);
+
+    $admin = User::factory()->create(['email' => 'boss@example.com']);
+    $plain = User::factory()->create(['email' => 'plain@example.com']);
+
+    expect(Gate::forUser($admin)->allows('viewTelescope'))->toBeTrue();
+    expect(Gate::forUser($admin)->allows('viewPulse'))->toBeTrue();
+    expect(Gate::forUser($plain)->allows('viewTelescope'))->toBeFalse();
+    expect(Gate::forUser($plain)->allows('viewPulse'))->toBeFalse();
+});

--- a/tests/Feature/BackupScheduleTest.php
+++ b/tests/Feature/BackupScheduleTest.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Console\Scheduling\Schedule;
+
+it('schedules the database backup and cleanup commands', function () {
+    $commands = collect(app(Schedule::class)->events())
+        ->map(fn ($event) => $event->command ?? '')
+        ->values();
+
+    expect($commands->contains(fn (string $c) => str_contains($c, 'backup:run')))->toBeTrue();
+    expect($commands->contains(fn (string $c) => str_contains($c, 'backup:clean')))->toBeTrue();
+});


### PR DESCRIPTION
## Phase 7 — Extras Integration (final rebuild phase)

Wires the Phase 0 extra packages into models/ops.

- **Activity logging** — `User` + `Team` use `LogsActivity` (`logOnlyDirty`). `User` logs only safe fields (`name`/`email`/`locale`/`theme_preference`), **never** password / 2FA / tokens. `Message` deliberately excluded (encrypted bodies).
- **Backup schedule** — nightly `backup:clean` then `backup:run --only-db` (01:00 / 01:30) in `routes/console.php`.
- **Admin-gated dashboards** — `User::isAdmin()` = `super_admin` role in **any** team (raw pivot query, since Spatie roles are team-scoped and the dashboards run outside team context) **OR** an allowlisted `config('app.admin_emails')`. Feeds Telescope's `viewTelescope` gate and a new `viewPulse` gate.

### Skipped (YAGNI)
Media-library avatars — Jetstream `HasProfilePhoto` already does avatars end-to-end; a second store would just be a bug farm. Media-library stays installed for real attachments later.

### Notes
- activitylog v5 stores the attribute diff in `attribute_changes`, not `properties` (tests assert accordingly).

### Verification
- Pest: 202 passed, 12 skipped, 0 failed
- PHPStan level 9: 0 errors
- Pint: clean
- Adversarial verify (3 lenses: gate bypass, activitylog PII, wiring): clean

Stacked on `chore/fresh-skeleton`. Completes the fresh-skeleton rebuild (Phases 1–7).