### PR TITLE
style: fix SearchController import ordering (pint)

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -5,9 +5,9 @@ namespace App\Http\Controllers\Api;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use App\Services\SearchService;
-use Illuminate\Pagination\LengthAwarePaginator;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class SearchController extends Controller
 {


### PR DESCRIPTION
Pint `ordered_imports` fix that slipped past Phase 5 (the git-less one-shot container reported `--dirty` as 0 files). Whole suite otherwise green: 202 pass, PHPStan L9 clean.