### PR TITLE
feat: admin-controlled site-wide theme

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,22 @@ Themes live under `themes/{name}/` (each with `theme.json` + `css/`/`js/`/`views
 
 **Per-theme Vite inputs are deferred** — `vite.config.js` builds only the main `app.css`/`app.js`. `@themeCss`/`@themeJs` gate on the Vite *manifest* (`ThemeManager::viteHasAsset`), so they emit nothing until `themes/*/{css,js}` are added to the Vite `input` and built — no 500. Wire those inputs in the PR that first ships a page extending a theme layout.
 
+Site-wide theme is admin-selectable via `SiteSettings::$active_theme` (Appearance
+section on the `ManageSiteSettings` page). Frontend resolution is
+`user.theme_preference → session → SiteSettings.active_theme → config('theme.default')`;
+each candidate is validated with `ThemeManager::themeExists()` before use, so a stale/invalid
+preference falls through instead of erroring. Because `ThemeManager` is a boot-once singleton
+(long-lived under Octane, reused within a test), the theme is **re-derived on every view
+render** in `ThemeServiceProvider`'s `View::composer('*', ...)`, not just once at boot — so an
+admin theme change (or a mid-lifecycle session/user pref) is picked up on the next render.
+Filament panels follow the **site-wide** theme only (no per-user panel theming):
+`AdminPanelProvider`/`AppPanelProvider` call
+`->colors(app(ThemeManager::class)->getFilamentColors(app(ThemeManager::class)->getSiteTheme()))`,
+which maps a theme's `theme.json` `colors.primary` (a Tailwind color name) to a Filament
+`Color` palette (unknown/missing → Amber). Compiled per-theme Filament CSS is **not** built
+yet; the reserved hook is a `theme.json` `filament_css` key + `->viteTheme()` on the panel,
+added when a theme needs its own Filament stylesheet.
+
 ### Multi-Language (Phase 3 — done)
 Supported locales live in `config('app.supported_locales')` (en/es/fr/de). `SetLocale` resolves locale (request param → session → `users.locale` → `Accept-Language` → default, validated against supported) and runs on the **`web` group** (`bootstrap/app.php`) **and both Filament panels** (added to each panel's `->middleware([])`, since Filament panels don't use the `web` group). Precedence is request > session > user (a stale session locale can shadow a freshly-logged-in user until logout flushes the session). `LanguageSwitcher` Livewire component persists to session + `users.locale`. `TranslationService` does on-demand translation via the MyMemory API (cached 30 days). No `locale_helpers`/`lang/*/messages` were ported (no callers); add `lang/` files only when something calls `__('...')`. The `LanguageSwitcher` component isn't mounted in any view yet — mount `<livewire:language-switcher />` where a switcher UI is wanted.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,9 @@ preference falls through instead of erroring. Because `ThemeManager` is a boot-o
 (long-lived under Octane, reused within a test), the theme is **re-derived on every view
 render** in `ThemeServiceProvider`'s `View::composer('*', ...)`, not just once at boot — so an
 admin theme change (or a mid-lifecycle session/user pref) is picked up on the next render.
-Filament panels follow the **site-wide** theme only (no per-user panel theming):
+This applies to frontend Blade rendering only: Filament panels evaluate `->colors()` once at
+worker boot, so under Octane a panel color change is only visible after a worker restart, not
+the next request. Filament panels follow the **site-wide** theme only (no per-user panel theming):
 `AdminPanelProvider`/`AppPanelProvider` call
 `->colors(app(ThemeManager::class)->getFilamentColors(app(ThemeManager::class)->getSiteTheme()))`,
 which maps a theme's `theme.json` `colors.primary` (a Tailwind color name) to a Filament

--- a/app/Filament/Pages/ManageSiteSettings.php
+++ b/app/Filament/Pages/ManageSiteSettings.php
@@ -2,7 +2,9 @@
 
 namespace App\Filament\Pages;
 
+use App\Services\ThemeManager;
 use App\Settings\SiteSettings;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
 use Filament\Pages\SettingsPage;
@@ -26,6 +28,20 @@ class ManageSiteSettings extends SettingsPage
         return $schema
             ->columns(1)
             ->components([
+                Section::make('Appearance')
+                    ->description('Site-wide theme. Users may still override this with their own preference.')
+                    ->schema([
+                        Select::make('active_theme')
+                            ->label('Site Theme')
+                            ->options(collect(app(ThemeManager::class)->getThemes())
+                                ->mapWithKeys(fn (array $config, string $name): array => [
+                                    $name => is_string($config['label'] ?? null) ? $config['label'] : ucfirst($name),
+                                ])
+                                ->all())
+                            ->required()
+                            ->native(false),
+                    ]),
+
                 Section::make('Site Information')
                     ->schema([
                         TextInput::make('site_name')

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers\Filament;
 
 use App\Http\Middleware\SetLocale;
 use App\Models\Team;
+use App\Services\ThemeManager;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use BezhanSalleh\FilamentShield\Middleware\SyncShieldTenant;
 use BezhanSalleh\FilamentShield\Support\Utils;
@@ -14,7 +15,6 @@ use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
-use Filament\Support\Colors\Color;
 use Filament\Widgets\AccountWidget;
 use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -33,9 +33,7 @@ class AdminPanelProvider extends PanelProvider
             ->id('admin')
             ->path('admin')
             ->login()
-            ->colors([
-                'primary' => Color::Amber,
-            ])
+            ->colors(app(ThemeManager::class)->getFilamentColors(app(ThemeManager::class)->getSiteTheme()))
             ->discoverResources(in: app_path('Filament/Resources'), for: 'App\Filament\Resources')
             ->discoverPages(in: app_path('Filament/Pages'), for: 'App\Filament\Pages')
             ->pages([

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Http\Middleware\SetLocale;
+use App\Services\ThemeManager;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -10,7 +11,6 @@ use Filament\Http\Middleware\DispatchServingFilamentEvent;
 use Filament\Pages\Dashboard;
 use Filament\Panel;
 use Filament\PanelProvider;
-use Filament\Support\Colors\Color;
 use Filament\Widgets\AccountWidget;
 use Filament\Widgets\FilamentInfoWidget;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -27,9 +27,7 @@ class AppPanelProvider extends PanelProvider
         return $panel
             ->id('app')
             ->path('app')
-            ->colors([
-                'primary' => Color::Amber,
-            ])
+            ->colors(app(ThemeManager::class)->getFilamentColors(app(ThemeManager::class)->getSiteTheme()))
             ->discoverResources(in: app_path('Filament/App/Resources'), for: 'App\Filament\App\Resources')
             ->discoverPages(in: app_path('Filament/App/Pages'), for: 'App\Filament\App\Pages')
             ->pages([

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -31,13 +31,21 @@ class ThemeServiceProvider extends ServiceProvider
         $this->registerBladeDirectives();
 
         View::composer('*', function (ViewContract $view) use ($themeManager): void {
+            // ponytail: re-derive per view render, not just once at boot. ThemeManager
+            // is a singleton resolved once per app lifecycle (long-lived under Octane;
+            // reused across a whole test method under Pest) — without this, an
+            // admin-changed site theme (or session/user pref set mid-lifecycle) would
+            // never be picked up until the process restarts. getSiteTheme() is a cheap
+            // in-memory settings read, so re-running this per view is negligible.
+            $themeManager->setTheme($this->determineActiveTheme());
+
             $view->with('activeTheme', $themeManager->getActiveTheme());
             $view->with('themeConfig', $themeManager->getThemeConfig());
         });
     }
 
     /**
-     * Determine the active theme: authenticated user preference → session → config default.
+     * Determine the active theme: authenticated user preference → session → site theme → config default.
      */
     protected function determineActiveTheme(): string
     {
@@ -51,9 +59,8 @@ class ThemeServiceProvider extends ServiceProvider
             return $session;
         }
 
-        $default = config('theme.default', 'default');
-
-        return is_string($default) ? $default : 'default';
+        // Admin-selected site-wide theme (validated; safe fallback to config default).
+        return $this->app->make(ThemeManager::class)->getSiteTheme();
     }
 
     /**

--- a/app/Providers/ThemeServiceProvider.php
+++ b/app/Providers/ThemeServiceProvider.php
@@ -49,18 +49,20 @@ class ThemeServiceProvider extends ServiceProvider
      */
     protected function determineActiveTheme(): string
     {
+        $themeManager = $this->app->make(ThemeManager::class);
+
         $user = auth()->user();
-        if ($user instanceof User && is_string($user->theme_preference) && $user->theme_preference !== '') {
+        if ($user instanceof User && is_string($user->theme_preference) && $user->theme_preference !== '' && $themeManager->themeExists($user->theme_preference)) {
             return $user->theme_preference;
         }
 
         $session = session('theme_preference');
-        if (is_string($session) && $session !== '') {
+        if (is_string($session) && $session !== '' && $themeManager->themeExists($session)) {
             return $session;
         }
 
         // Admin-selected site-wide theme (validated; safe fallback to config default).
-        return $this->app->make(ThemeManager::class)->getSiteTheme();
+        return $themeManager->getSiteTheme();
     }
 
     /**

--- a/app/Services/ThemeManager.php
+++ b/app/Services/ThemeManager.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Settings\SiteSettings;
+use Filament\Support\Colors\Color;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\View;
@@ -215,6 +216,58 @@ class ThemeManager
         $theme = $theme ?? $this->activeTheme;
 
         return $this->themes[$theme] ?? [];
+    }
+
+    /**
+     * Whitelist of Tailwind color names → Filament Color palettes. Explicit map
+     * (not dynamic constant lookup) so an unexpected theme.json value can never
+     * reference an undefined constant.
+     *
+     * @return array<string, array<int|string, string>>
+     */
+    protected function filamentColorMap(): array
+    {
+        return [
+            'slate' => Color::Slate,
+            'gray' => Color::Gray,
+            'zinc' => Color::Zinc,
+            'neutral' => Color::Neutral,
+            'stone' => Color::Stone,
+            'red' => Color::Red,
+            'orange' => Color::Orange,
+            'amber' => Color::Amber,
+            'yellow' => Color::Yellow,
+            'lime' => Color::Lime,
+            'green' => Color::Green,
+            'emerald' => Color::Emerald,
+            'teal' => Color::Teal,
+            'cyan' => Color::Cyan,
+            'sky' => Color::Sky,
+            'blue' => Color::Blue,
+            'indigo' => Color::Indigo,
+            'violet' => Color::Violet,
+            'purple' => Color::Purple,
+            'fuchsia' => Color::Fuchsia,
+            'pink' => Color::Pink,
+            'rose' => Color::Rose,
+        ];
+    }
+
+    /**
+     * Build the Filament panel color palette for a theme from its theme.json
+     * `colors.primary`. Unknown or missing → Amber (the shipped default look).
+     *
+     * @return array<string, array<int|string, string>>
+     */
+    public function getFilamentColors(?string $theme = null): array
+    {
+        $config = $this->getThemeConfig($theme);
+        $colors = is_array($config['colors'] ?? null) ? $config['colors'] : [];
+        $primary = is_string($colors['primary'] ?? null) ? strtolower($colors['primary']) : 'amber';
+
+        $map = $this->filamentColorMap();
+
+        return ['primary' => $map[$primary] ?? Color::Amber];
     }
 
     /**

--- a/app/Services/ThemeManager.php
+++ b/app/Services/ThemeManager.php
@@ -2,10 +2,12 @@
 
 namespace App\Services;
 
+use App\Settings\SiteSettings;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\View;
 use Illuminate\View\FileViewFinder;
+use Throwable;
 
 class ThemeManager
 {
@@ -68,6 +70,24 @@ class ThemeManager
     public function getActiveTheme(): string
     {
         return $this->activeTheme;
+    }
+
+    /**
+     * The admin-selected site-wide theme, or the config default when the
+     * setting is unavailable or names a theme that does not exist. Never throws.
+     */
+    public function getSiteTheme(): string
+    {
+        $default = config('theme.default', 'default');
+        $default = is_string($default) ? $default : 'default';
+
+        try {
+            $theme = app(SiteSettings::class)->active_theme;
+        } catch (Throwable) {
+            return $default;
+        }
+
+        return $this->themeExists($theme) ? $theme : $default;
     }
 
     /**

--- a/app/Services/ThemeManager.php
+++ b/app/Services/ThemeManager.php
@@ -152,10 +152,29 @@ class ThemeManager
         $themeViewsPath = $this->getThemeViewsPath();
         $finder = View::getFinder();
 
-        if (File::exists($themeViewsPath) && $finder instanceof FileViewFinder) {
-            // Add theme views path before the default views path
-            $finder->prependLocation($themeViewsPath);
+        if (! File::exists($themeViewsPath) || ! $finder instanceof FileViewFinder) {
+            return;
         }
+
+        $resolvedPath = realpath($themeViewsPath) ?: $themeViewsPath;
+        $paths = $finder->getPaths();
+
+        if (($paths[0] ?? null) === $resolvedPath) {
+            // Already registered and already has top priority: prependLocation() has no
+            // dedupe, and this runs per view render (via ThemeServiceProvider's
+            // View::composer), so re-adding it every render would grow the finder's
+            // paths array unbounded under Octane.
+            return;
+        }
+
+        // Drop any stale registration of this theme's path before re-prepending, so
+        // switching themes mid-worker (a different theme was prepended after this one)
+        // still gives the newly active theme priority instead of leaving it shadowed.
+        // Prepend the realpath (the same value used for the dedupe check above) so a
+        // symlinked deploy path (e.g. Octane atomic releases) stays idempotent — a raw
+        // path here would never match $resolvedPath and would accumulate every render.
+        $finder->setPaths(array_values(array_diff($paths, [$resolvedPath])));
+        $finder->prependLocation($resolvedPath);
     }
 
     /**
@@ -223,7 +242,7 @@ class ThemeManager
      * (not dynamic constant lookup) so an unexpected theme.json value can never
      * reference an undefined constant.
      *
-     * @return array<string, array<int|string, string>>
+     * @return array<string, array<int, string>>
      */
     protected function filamentColorMap(): array
     {
@@ -257,7 +276,7 @@ class ThemeManager
      * Build the Filament panel color palette for a theme from its theme.json
      * `colors.primary`. Unknown or missing → Amber (the shipped default look).
      *
-     * @return array<string, array<int|string, string>>
+     * @return array<string, array<int, string>>
      */
     public function getFilamentColors(?string $theme = null): array
     {

--- a/app/Settings/SiteSettings.php
+++ b/app/Settings/SiteSettings.php
@@ -30,6 +30,8 @@ class SiteSettings extends Settings
 
     public string $footer_copyright;
 
+    public string $active_theme;
+
     public static function group(): string
     {
         return 'site';

--- a/database/settings/2026_07_01_000000_add_active_theme_to_site_settings.php
+++ b/database/settings/2026_07_01_000000_add_active_theme_to_site_settings.php
@@ -1,0 +1,11 @@
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class() extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('site.active_theme', 'default');
+    }
+};

--- a/docs/superpowers/plans/2026-07-01-admin-themes.md
+++ b/docs/superpowers/plans/2026-07-01-admin-themes.md
@@ -1,0 +1,725 @@
+# Admin-Controlled Site Theme Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let an admin pick the site-wide theme from the Filament admin panel, restyling both frontend Blade and Filament panels, with zero visual change on ship.
+
+**Architecture:** Add a single `SiteSettings.active_theme` field. The frontend theme resolver inserts it between session and config fallback; the Filament panel providers feed the active site theme's `theme.json` colors into `->colors()`. All theming infrastructure (`ThemeManager`, `ThemeServiceProvider`, per-user switcher, `themes/`) already exists and is reused.
+
+**Tech Stack:** Laravel 13, PHP 8.5, Filament v5, `spatie/laravel-settings`, Pest 5 / PHPUnit 13 (SQLite `:memory:`), run inside the `php-fpm` Docker container.
+
+## Global Constraints
+
+- All commands run inside Docker: prefix with `docker compose exec -T php-fpm`. Never run `php`/`composer` on the host.
+- All git operations run **inside `src/`** (the app repo). Never commit to the parent infra repo.
+- TDD: write the failing test first, confirm it fails, then implement, then confirm green.
+- Every changed file under `app/` must pass `vendor/bin/phpstan analyse` at level 5 and `vendor/bin/pint --test`.
+- Filament panel colors currently use `Filament\Support\Colors\Color::Amber` — the default theme MUST keep the Amber primary (no visual change on ship).
+- Frontend theme resolution order (final): `user.theme_preference → session('theme_preference') → ThemeManager::getSiteTheme() → config('theme.default')`.
+- `ThemeManager::getSiteTheme()` and `getFilamentColors()` MUST NEVER throw (safe fallback), so console/migrations/boot never break.
+
+---
+
+### Task 0: Fix test APP_KEY (prerequisite)
+
+Filament page tests (Task 5) render the panel, which needs an encryption key. Tests currently fail with `MissingAppKeyException` because `phpunit.xml` sets no `APP_KEY`. This task is a prerequisite and also fixes ~38 pre-existing failures.
+
+**Files:**
+- Modify: `phpunit.xml` (the `<php>` env block, around lines 20-34)
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: a stable encryption key for the `testing` environment
+
+- [ ] **Step 1: Confirm the failure exists**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/ManageSiteSettingsPageTest.php 2>&1 | tail -8`
+Expected: FAIL mentioning `MissingAppKeyException`.
+
+- [ ] **Step 2: Add APP_KEY to phpunit.xml**
+
+In `phpunit.xml`, inside `<php>`, add this line just after the `APP_ENV` env entry:
+
+```xml
+        <env name="APP_KEY" value="base64:3xVFJ5tTr05dWL1gsJqF+UvWdv3X0Cz/CBaUG47hb3U="/>
+```
+
+- [ ] **Step 3: Confirm the pre-existing tests now pass**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/ManageSiteSettingsPageTest.php 2>&1 | tail -8`
+Expected: PASS (2 passed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add phpunit.xml
+git commit -m "test: set fixed APP_KEY in phpunit.xml (fixes MissingAppKeyException)"
+```
+
+---
+
+### Task 1: Add `active_theme` to SiteSettings
+
+**Files:**
+- Create: `database/settings/2026_07_01_000000_add_active_theme_to_site_settings.php`
+- Modify: `app/Settings/SiteSettings.php` (add one property)
+- Test: `tests/Feature/SiteSettingsActiveThemeTest.php`
+
+**Interfaces:**
+- Consumes: nothing
+- Produces: `SiteSettings::$active_theme` (`string`, default `'default'`)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/SiteSettingsActiveThemeTest.php`:
+
+```php
+<?php
+
+use App\Settings\SiteSettings;
+
+it('exposes active_theme defaulting to the default theme', function () {
+    expect(app(SiteSettings::class)->active_theme)->toBe('default');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/SiteSettingsActiveThemeTest.php`
+Expected: FAIL — property `active_theme` not defined / settings property missing.
+
+- [ ] **Step 3: Add the settings migration**
+
+Create `database/settings/2026_07_01_000000_add_active_theme_to_site_settings.php`:
+
+```php
+<?php
+
+use Spatie\LaravelSettings\Migrations\SettingsMigration;
+
+return new class() extends SettingsMigration
+{
+    public function up(): void
+    {
+        $this->migrator->add('site.active_theme', 'default');
+    }
+};
+```
+
+- [ ] **Step 4: Add the property to SiteSettings**
+
+In `app/Settings/SiteSettings.php`, add after `public string $footer_copyright;`:
+
+```php
+    public string $active_theme;
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/SiteSettingsActiveThemeTest.php`
+Expected: PASS.
+
+- [ ] **Step 6: Pint + PHPStan**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pint app/Settings/SiteSettings.php && docker compose exec -T php-fpm vendor/bin/phpstan analyse app/Settings/SiteSettings.php`
+Expected: PASS, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add database/settings/2026_07_01_000000_add_active_theme_to_site_settings.php app/Settings/SiteSettings.php tests/Feature/SiteSettingsActiveThemeTest.php
+git commit -m "feat(settings): add active_theme site setting"
+```
+
+---
+
+### Task 2: `ThemeManager::getSiteTheme()`
+
+**Files:**
+- Modify: `app/Services/ThemeManager.php` (add method)
+- Test: `tests/Unit/ThemeManagerSiteThemeTest.php`
+
+**Interfaces:**
+- Consumes: `SiteSettings::$active_theme` (Task 1), existing `ThemeManager::themeExists()`
+- Produces: `ThemeManager::getSiteTheme(): string` — the persisted site theme, or `config('theme.default','default')` on any failure or unknown theme. Never throws.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Unit/ThemeManagerSiteThemeTest.php`:
+
+```php
+<?php
+
+use App\Services\ThemeManager;
+use App\Settings\SiteSettings;
+
+it('returns the persisted site theme', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'dark';
+    $settings->save();
+
+    expect(app(ThemeManager::class)->getSiteTheme())->toBe('dark');
+});
+
+it('falls back to config default when the site theme is unknown', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'no-such-theme';
+    $settings->save();
+
+    expect(app(ThemeManager::class)->getSiteTheme())->toBe(config('theme.default'));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Unit/ThemeManagerSiteThemeTest.php`
+Expected: FAIL — `getSiteTheme` not defined.
+
+- [ ] **Step 3: Implement `getSiteTheme()`**
+
+In `app/Services/ThemeManager.php`, add this method (and the `use` for `SiteSettings` and `Throwable` at the top):
+
+At the top with the other `use` statements:
+
+```php
+use App\Settings\SiteSettings;
+use Throwable;
+```
+
+Method (place after `getActiveTheme()`):
+
+```php
+    /**
+     * The admin-selected site-wide theme, or the config default when the
+     * setting is unavailable or names a theme that does not exist. Never throws.
+     */
+    public function getSiteTheme(): string
+    {
+        $default = config('theme.default', 'default');
+        $default = is_string($default) ? $default : 'default';
+
+        try {
+            $theme = app(SiteSettings::class)->active_theme;
+        } catch (Throwable) {
+            return $default;
+        }
+
+        return $this->themeExists($theme) ? $theme : $default;
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Unit/ThemeManagerSiteThemeTest.php`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Pint + PHPStan**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pint app/Services/ThemeManager.php && docker compose exec -T php-fpm vendor/bin/phpstan analyse app/Services/ThemeManager.php`
+Expected: PASS, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add app/Services/ThemeManager.php tests/Unit/ThemeManagerSiteThemeTest.php
+git commit -m "feat(theme): ThemeManager::getSiteTheme() reads admin site theme"
+```
+
+---
+
+### Task 3: `ThemeManager::getFilamentColors()` + default theme colors
+
+**Files:**
+- Modify: `app/Services/ThemeManager.php` (add method + color map)
+- Modify: `themes/default/theme.json` (set `colors.primary` to `amber`)
+- Test: `tests/Unit/ThemeManagerFilamentColorsTest.php`
+
+**Interfaces:**
+- Consumes: existing `ThemeManager::getThemeConfig()`
+- Produces: `ThemeManager::getFilamentColors(?string $theme = null): array` — returns `['primary' => <Color const>]`, mapping the theme's `colors.primary` (lowercase Tailwind name) to a `Filament\Support\Colors\Color` constant. Unknown/missing → `['primary' => Color::Amber]`.
+
+- [ ] **Step 1: Set the default theme's primary color to amber**
+
+Edit `themes/default/theme.json` so the `colors` block is:
+
+```json
+    "colors": {
+        "primary": "amber",
+        "secondary": "slate"
+    }
+```
+
+(This preserves the current Amber panel look.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/Unit/ThemeManagerFilamentColorsTest.php`:
+
+```php
+<?php
+
+use App\Services\ThemeManager;
+use Filament\Support\Colors\Color;
+
+it('maps the default theme primary color to the Amber Filament palette', function () {
+    $colors = app(ThemeManager::class)->getFilamentColors('default');
+
+    expect($colors)->toHaveKey('primary');
+    expect($colors['primary'])->toBe(Color::Amber);
+});
+
+it('maps the dark theme primary color to the Indigo Filament palette', function () {
+    $colors = app(ThemeManager::class)->getFilamentColors('dark');
+
+    expect($colors['primary'])->toBe(Color::Indigo);
+});
+
+it('falls back to Amber for an unknown color name', function () {
+    // A theme with no colors block resolves to the Amber default.
+    $colors = app(ThemeManager::class)->getFilamentColors('no-such-theme');
+
+    expect($colors['primary'])->toBe(Color::Amber);
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Unit/ThemeManagerFilamentColorsTest.php`
+Expected: FAIL — `getFilamentColors` not defined.
+
+- [ ] **Step 4: Implement `getFilamentColors()`**
+
+In `app/Services/ThemeManager.php`, add the `use` at the top:
+
+```php
+use Filament\Support\Colors\Color;
+```
+
+Add these members (place after `getThemeConfig()`):
+
+```php
+    /**
+     * Whitelist of Tailwind color names → Filament Color palettes. Explicit map
+     * (not dynamic constant lookup) so an unexpected theme.json value can never
+     * reference an undefined constant.
+     *
+     * @return array<string, array<int|string, string>>
+     */
+    protected function filamentColorMap(): array
+    {
+        return [
+            'slate' => Color::Slate,
+            'gray' => Color::Gray,
+            'zinc' => Color::Zinc,
+            'neutral' => Color::Neutral,
+            'stone' => Color::Stone,
+            'red' => Color::Red,
+            'orange' => Color::Orange,
+            'amber' => Color::Amber,
+            'yellow' => Color::Yellow,
+            'lime' => Color::Lime,
+            'green' => Color::Green,
+            'emerald' => Color::Emerald,
+            'teal' => Color::Teal,
+            'cyan' => Color::Cyan,
+            'sky' => Color::Sky,
+            'blue' => Color::Blue,
+            'indigo' => Color::Indigo,
+            'violet' => Color::Violet,
+            'purple' => Color::Purple,
+            'fuchsia' => Color::Fuchsia,
+            'pink' => Color::Pink,
+            'rose' => Color::Rose,
+        ];
+    }
+
+    /**
+     * Build the Filament panel color palette for a theme from its theme.json
+     * `colors.primary`. Unknown or missing → Amber (the shipped default look).
+     *
+     * @return array<string, array<int|string, string>>
+     */
+    public function getFilamentColors(?string $theme = null): array
+    {
+        $config = $this->getThemeConfig($theme);
+        $colors = is_array($config['colors'] ?? null) ? $config['colors'] : [];
+        $primary = is_string($colors['primary'] ?? null) ? strtolower($colors['primary']) : 'amber';
+
+        $map = $this->filamentColorMap();
+
+        return ['primary' => $map[$primary] ?? Color::Amber];
+    }
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Unit/ThemeManagerFilamentColorsTest.php`
+Expected: PASS (3 passed).
+
+- [ ] **Step 6: Pint + PHPStan**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pint app/Services/ThemeManager.php && docker compose exec -T php-fpm vendor/bin/phpstan analyse app/Services/ThemeManager.php`
+Expected: PASS, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add app/Services/ThemeManager.php themes/default/theme.json tests/Unit/ThemeManagerFilamentColorsTest.php
+git commit -m "feat(theme): map theme.json colors to Filament palette"
+```
+
+---
+
+### Task 4: Frontend resolution honors the site theme
+
+**Files:**
+- Modify: `app/Providers/ThemeServiceProvider.php` (`determineActiveTheme()`)
+- Test: `tests/Feature/ThemeSiteResolutionTest.php`
+
+**Interfaces:**
+- Consumes: `ThemeManager::getSiteTheme()` (Task 2)
+- Produces: updated resolution order `user → session → site → config`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/ThemeSiteResolutionTest.php`:
+
+```php
+<?php
+
+use App\Services\ThemeManager;
+use App\Settings\SiteSettings;
+
+it('uses the site theme when no user or session preference is set', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'dark';
+    $settings->save();
+
+    // Re-boot the provider path by resolving a fresh ThemeManager via a request.
+    $this->get('/');
+
+    expect(app(ThemeManager::class)->getActiveTheme())->toBe('dark');
+});
+
+it('lets a session preference win over the site theme', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'dark';
+    $settings->save();
+
+    session(['theme_preference' => 'default']);
+    $this->get('/');
+
+    expect(app(ThemeManager::class)->getActiveTheme())->toBe('default');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/ThemeSiteResolutionTest.php`
+Expected: FAIL — active theme is `default` (config), site layer not consulted.
+
+- [ ] **Step 3: Insert the site layer in `determineActiveTheme()`**
+
+In `app/Providers/ThemeServiceProvider.php`, replace the body of `determineActiveTheme()` (currently: user pref → session → config default) with:
+
+```php
+    protected function determineActiveTheme(): string
+    {
+        $user = auth()->user();
+        if ($user instanceof User && is_string($user->theme_preference) && $user->theme_preference !== '') {
+            return $user->theme_preference;
+        }
+
+        $session = session('theme_preference');
+        if (is_string($session) && $session !== '') {
+            return $session;
+        }
+
+        // Admin-selected site-wide theme (validated; safe fallback to config default).
+        return $this->app->make(ThemeManager::class)->getSiteTheme();
+    }
+```
+
+(`getSiteTheme()` already falls back to `config('theme.default')`, so the old config branch is subsumed. `ThemeManager` is already imported in this file.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/ThemeSiteResolutionTest.php`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Run the existing theme tests for regressions**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/ThemeServiceProviderTest.php tests/Feature/ThemeSwitcherTest.php tests/Unit/ThemeManagerTest.php`
+Expected: PASS (no regressions).
+
+- [ ] **Step 6: Pint + PHPStan**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pint app/Providers/ThemeServiceProvider.php && docker compose exec -T php-fpm vendor/bin/phpstan analyse app/Providers/ThemeServiceProvider.php`
+Expected: PASS, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add app/Providers/ThemeServiceProvider.php tests/Feature/ThemeSiteResolutionTest.php
+git commit -m "feat(theme): frontend resolution honors admin site theme"
+```
+
+---
+
+### Task 5: Admin Select on ManageSiteSettings
+
+**Files:**
+- Modify: `app/Filament/Pages/ManageSiteSettings.php` (add an Appearance section with a Select)
+- Test: `tests/Feature/ManageSiteSettingsThemeTest.php`
+
+**Interfaces:**
+- Consumes: `SiteSettings::$active_theme` (Task 1), `ThemeManager::getThemes()` (existing)
+- Produces: an `active_theme` form field that persists
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/ManageSiteSettingsThemeTest.php`:
+
+```php
+<?php
+
+use App\Filament\Pages\ManageSiteSettings;
+use App\Models\User;
+use App\Settings\SiteSettings;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    $this->actingAs(User::factory()->create());
+});
+
+it('renders the active_theme field', function () {
+    Livewire::test(ManageSiteSettings::class)
+        ->assertOk()
+        ->assertFormFieldExists('active_theme');
+});
+
+it('persists a chosen theme', function () {
+    Livewire::test(ManageSiteSettings::class)
+        ->fillForm(['active_theme' => 'dark'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    app()->forgetInstance(SiteSettings::class);
+
+    expect(app(SiteSettings::class)->active_theme)->toBe('dark');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/ManageSiteSettingsThemeTest.php`
+Expected: FAIL — form field `active_theme` does not exist.
+
+- [ ] **Step 3: Add the Select to the form**
+
+In `app/Filament/Pages/ManageSiteSettings.php`, add the import at the top with the other Filament form component imports:
+
+```php
+use App\Services\ThemeManager;
+use Filament\Forms\Components\Select;
+```
+
+Add a new section as the **first** component in the `->components([ ... ])` array (before `Section::make('Site Information')`):
+
+```php
+                Section::make('Appearance')
+                    ->description('Site-wide theme. Users may still override this with their own preference.')
+                    ->schema([
+                        Select::make('active_theme')
+                            ->label('Site Theme')
+                            ->options(collect(app(ThemeManager::class)->getThemes())
+                                ->mapWithKeys(fn (array $config, string $name): array => [
+                                    $name => is_string($config['label'] ?? null) ? $config['label'] : ucfirst($name),
+                                ])
+                                ->all())
+                            ->required()
+                            ->native(false),
+                    ]),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/ManageSiteSettingsThemeTest.php`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Pint + PHPStan**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pint app/Filament/Pages/ManageSiteSettings.php && docker compose exec -T php-fpm vendor/bin/phpstan analyse app/Filament/Pages/ManageSiteSettings.php`
+Expected: PASS, no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add app/Filament/Pages/ManageSiteSettings.php tests/Feature/ManageSiteSettingsThemeTest.php
+git commit -m "feat(admin): choose site theme on ManageSiteSettings page"
+```
+
+---
+
+### Task 6: Filament panels use the site theme palette
+
+**Files:**
+- Modify: `app/Providers/Filament/AdminPanelProvider.php` (`->colors(...)`)
+- Modify: `app/Providers/Filament/AppPanelProvider.php` (`->colors(...)`)
+- Test: `tests/Feature/PanelThemeColorsTest.php`
+
+**Interfaces:**
+- Consumes: `ThemeManager::getSiteTheme()` (Task 2), `ThemeManager::getFilamentColors()` (Task 3)
+- Produces: panels whose primary color follows the site theme
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/Feature/PanelThemeColorsTest.php`:
+
+```php
+<?php
+
+use App\Services\ThemeManager;
+use Filament\Facades\Filament;
+use Filament\Support\Colors\Color;
+
+it('admin panel primary color follows the site theme', function () {
+    // getFilamentColors('dark') → Indigo; assert the resolver returns it so the
+    // panel provider (which passes this array to ->colors()) is driven by the theme.
+    expect(app(ThemeManager::class)->getFilamentColors('dark')['primary'])->toBe(Color::Indigo);
+    expect(app(ThemeManager::class)->getFilamentColors('default')['primary'])->toBe(Color::Amber);
+
+    // Panel registers without error using the theme-driven palette.
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    expect(Filament::getPanel('admin'))->not->toBeNull();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails or passes-trivially, then wire the providers**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/PanelThemeColorsTest.php`
+Expected: the color assertions PASS (Task 3 done); this step exists to lock behavior. Proceed to wire the providers so the palette is actually theme-driven.
+
+- [ ] **Step 3: Wire AdminPanelProvider**
+
+In `app/Providers/Filament/AdminPanelProvider.php`, add the import:
+
+```php
+use App\Services\ThemeManager;
+```
+
+Replace:
+
+```php
+            ->colors([
+                'primary' => Color::Amber,
+            ])
+```
+
+with:
+
+```php
+            ->colors(app(ThemeManager::class)->getFilamentColors(app(ThemeManager::class)->getSiteTheme()))
+```
+
+- [ ] **Step 4: Wire AppPanelProvider**
+
+In `app/Providers/Filament/AppPanelProvider.php`, add the import:
+
+```php
+use App\Services\ThemeManager;
+```
+
+Replace:
+
+```php
+            ->colors([
+                'primary' => Color::Amber,
+            ])
+```
+
+with:
+
+```php
+            ->colors(app(ThemeManager::class)->getFilamentColors(app(ThemeManager::class)->getSiteTheme()))
+```
+
+(If `Color` is now unused in a provider, remove its `use Filament\Support\Colors\Color;` import — Pint will flag it.)
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest tests/Feature/PanelThemeColorsTest.php`
+Expected: PASS.
+
+- [ ] **Step 6: Pint + PHPStan**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pint app/Providers/Filament/AdminPanelProvider.php app/Providers/Filament/AppPanelProvider.php && docker compose exec -T php-fpm vendor/bin/phpstan analyse app/Providers/Filament/AdminPanelProvider.php app/Providers/Filament/AppPanelProvider.php`
+Expected: PASS, no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add app/Providers/Filament/AdminPanelProvider.php app/Providers/Filament/AppPanelProvider.php tests/Feature/PanelThemeColorsTest.php
+git commit -m "feat(admin): Filament panels follow site theme palette"
+```
+
+---
+
+### Task 7: Document the compiled-CSS hook + full suite green
+
+**Files:**
+- Modify: `CLAUDE.md` (Theme System section — note admin site theme + Filament color mechanism)
+
+**Interfaces:**
+- Consumes: everything above
+- Produces: documentation + a green full test run
+
+- [ ] **Step 1: Update CLAUDE.md Theme System section**
+
+In `src/CLAUDE.md`, in the `### Theme System` section, append:
+
+```
+Site-wide theme is admin-selectable via `SiteSettings.active_theme` (Appearance
+section on the ManageSiteSettings page). Frontend resolution is
+`user pref → session → SiteSettings.active_theme → config('theme.default')`.
+Filament panels follow the **site-wide** theme only: `AdminPanelProvider`/
+`AppPanelProvider` call `->colors(ThemeManager::getFilamentColors(getSiteTheme()))`,
+which maps a theme's `theme.json` `colors.primary` (a Tailwind name) to a Filament
+`Color` palette. Compiled per-theme Filament CSS is NOT built yet; add a
+`theme.json` `filament_css` key + `->viteTheme()` when a theme needs it.
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pest 2>&1 | tail -6`
+Expected: PASS — 0 failed (Task 0 cleared the pre-existing `MissingAppKeyException` failures; the new theme tests are green).
+
+- [ ] **Step 3: Full Pint + PHPStan**
+
+Run: `docker compose exec -T php-fpm vendor/bin/pint --test && docker compose exec -T php-fpm vendor/bin/phpstan analyse`
+Expected: PASS, no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/tom/code/boilerplate-laravel/src
+git add CLAUDE.md
+git commit -m "docs: document admin site theme + Filament color mechanism"
+```
+
+---
+
+## Notes for the implementer
+
+- The default theme MUST stay Amber (Task 3 sets `themes/default/theme.json` `colors.primary = amber`). If the admin selects `dark`, panels go Indigo and the frontend loads the dark theme — that is the demonstration that the mechanism works end to end.
+- One PR for this whole plan (label `enhancement`, reviewer `curtisdelicata`, branch off `main`), per repo conventions.
+- Filament panels read the site theme at request boot; a theme change is visible on the next request (no per-user panel theming — that is intentionally deferred).

--- a/docs/superpowers/specs/2026-07-01-admin-themes-design.md
+++ b/docs/superpowers/specs/2026-07-01-admin-themes-design.md
@@ -1,0 +1,113 @@
+# Admin-Controlled Site Theme — Design Spec
+
+**Date:** 2026-07-01
+**Status:** Approved (brainstorming)
+
+## Problem
+
+The app already has a full theming stack (`ThemeManager`, `ThemeServiceProvider`,
+per-user `ThemeSwitcher`, `config/theme.php`, `themes/default` + `themes/dark`,
+`users.theme_preference`, tests). What's missing is an **admin-panel control that
+sets a site-wide theme**. Today the active theme resolves only from
+`user preference → session → config('theme.default')`; there is no runtime,
+admin-editable site default.
+
+## Goal
+
+Let an admin choose the site-wide theme from the Filament admin panel. Ship with
+**one default theme** and **no visual change** (default theme reproduces the
+current Amber-primary look). Adding a theme later = drop a folder + `theme.json`.
+
+## Scope Decisions (from brainstorming)
+
+1. **Admin scope:** Admin sets the site **default**; individual users can still
+   override via the existing per-user switcher.
+   Frontend resolution becomes: `user pref → session → site theme → config fallback`.
+2. **Surfaces:** Theme restyles **frontend Blade** *and* **Filament panels**.
+3. **Filament depth:** Drive Filament panel **color palette** from `theme.json`
+   now; reserve a documented hook (`theme.json.filament_css`) for future compiled
+   per-theme CSS. No compiled Filament CSS per theme in this iteration.
+4. **Panel boundary:** Filament panels follow the **site-wide** theme only (not
+   per-user) — panel config resolves once at request boot; per-user panel theming
+   is deferred.
+
+## Architecture
+
+```
+Admin (ManageSiteSettings) → SiteSettings.active_theme ─┬─ Frontend: ThemeServiceProvider
+                                                         │   resolution (user → session → SITE → config)
+                                                         └─ Filament: AdminPanelProvider + AppPanelProvider
+                                                             ->colors( ThemeManager::getFilamentColors(site) )
+```
+
+Single new concept: `SiteSettings.active_theme`. Everything else reads it.
+
+## Components
+
+| Unit | Change | Responsibility |
+|------|--------|----------------|
+| `App\Settings\SiteSettings` | add `public string $active_theme` | Site-wide theme, one source of truth |
+| `database/settings/*_add_active_theme_to_site_settings.php` | `migrator->add('site.active_theme','default')` | Non-null default so app/tests boot |
+| `App\Filament\Pages\ManageSiteSettings` | add `Select` (options ← `ThemeManager::getThemes()`) in a new "Appearance" section | Admin control |
+| `App\Services\ThemeManager` | + `getSiteTheme(): string`, + `getFilamentColors(?string $theme): array` | Read site theme (DB, safe fallback); map `theme.json.colors` → Filament palette |
+| `App\Providers\ThemeServiceProvider::determineActiveTheme()` | insert `getSiteTheme()` between session and config; validate theme exists | Frontend honors admin choice |
+| `App\Providers\Filament\AdminPanelProvider` + `AppPanelProvider` | `->colors($themeManager->getFilamentColors($themeManager->getSiteTheme()))` | Panels restyle per site theme |
+| `themes/default/theme.json` | set `colors.primary` = `amber` (+ `secondary`); add note re `filament_css` hook | Preserve current look; document extension point |
+| `phpunit.xml` | add fixed test `APP_KEY` | Unblock Filament page tests (pre-existing `MissingAppKeyException`) |
+
+## Interfaces
+
+```php
+// ThemeManager
+public function getSiteTheme(): string;
+// Reads SiteSettings.active_theme; on any failure (DB missing, setting absent,
+// unknown theme) returns config('theme.default','default'). Never throws.
+
+public function getFilamentColors(?string $theme = null): array;
+// Returns e.g. ['primary' => Color::Amber]. Reads theme.json 'colors.primary'
+// (a lowercase Tailwind name), maps to a Filament Color const. Unknown/missing
+// color → ['primary' => Color::Amber]. Shape is a valid argument to Filament
+// panel ->colors().
+```
+
+## Frontend resolution (final order)
+
+`user.theme_preference (if non-empty) → session('theme_preference') → ThemeManager::getSiteTheme() → config('theme.default')`.
+Any resolved value that isn't a real theme falls through to the next source; the
+final config value is guaranteed to exist (`themes/default`).
+
+## Data flow
+
+- **Frontend:** `ThemeServiceProvider::boot()` calls `setTheme(determineActiveTheme())`
+  per request; unchanged except the new site layer.
+- **Filament panels:** each provider calls
+  `->colors($tm->getFilamentColors($tm->getSiteTheme()))` at panel registration.
+  DB read is wrapped safely so console/migrations don't break.
+
+## Color contract (`theme.json`)
+
+```json
+"colors": { "primary": "amber", "secondary": "slate" }
+```
+`ThemeManager::getFilamentColors()` maps `primary` via an explicit whitelist to a
+`Filament\Support\Colors\Color` const. Future compiled Filament CSS would be
+declared as an optional `"filament_css": "themes/<name>/filament.css"` key and
+wired via `->viteTheme()` — **not** built in this iteration.
+
+## Testing (TDD)
+
+1. After migrate, `app(SiteSettings::class)->active_theme === 'default'`.
+2. `getSiteTheme()` returns the persisted value; returns config default when the
+   setting is an unknown/absent theme.
+3. `getFilamentColors('default')` returns `['primary' => Color::Amber]`;
+   `getFilamentColors()` on a theme with no `colors` returns the Amber default.
+4. `determineActiveTheme()` returns the site theme when no user/session pref set;
+   user pref still wins when present.
+5. `ManageSiteSettings` renders an `active_theme` field and persists a new value.
+6. A panel provider's resolved primary color reflects the active site theme.
+
+## Out of scope (YAGNI — documented hooks left)
+
+- Compiled per-theme Filament CSS / fonts / radius (`filament_css` key reserved).
+- Per-user Filament panel theming (panels are site-wide).
+- Shipping additional themes (mechanism proven with `default`; `dark` already on disk).

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:3xVFJ5tTr05dWL1gsJqF+UvWdv3X0Cz/CBaUG47hb3U="/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/tests/Feature/ManageSiteSettingsThemeTest.php
+++ b/tests/Feature/ManageSiteSettingsThemeTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use App\Filament\Pages\ManageSiteSettings;
+use App\Models\User;
+use App\Settings\SiteSettings;
+use Filament\Facades\Filament;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    $this->actingAs(User::factory()->create());
+});
+
+it('renders the active_theme field', function () {
+    Livewire::test(ManageSiteSettings::class)
+        ->assertOk()
+        ->assertFormFieldExists('active_theme');
+});
+
+it('persists a chosen theme', function () {
+    Livewire::test(ManageSiteSettings::class)
+        ->fillForm(['active_theme' => 'dark'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    app()->forgetInstance(SiteSettings::class);
+
+    expect(app(SiteSettings::class)->active_theme)->toBe('dark');
+});

--- a/tests/Feature/PanelThemeColorsTest.php
+++ b/tests/Feature/PanelThemeColorsTest.php
@@ -1,16 +1,43 @@
 <?php
 
+use App\Providers\Filament\AdminPanelProvider;
+use App\Providers\Filament\AppPanelProvider;
 use App\Services\ThemeManager;
-use Filament\Facades\Filament;
+use App\Settings\SiteSettings;
+use Filament\Panel;
 use Filament\Support\Colors\Color;
 
-it('admin panel primary color follows the site theme', function () {
-    // getFilamentColors('dark') → Indigo; assert the resolver returns it so the
-    // panel provider (which passes this array to ->colors()) is driven by the theme.
-    expect(app(ThemeManager::class)->getFilamentColors('dark')['primary'])->toBe(Color::Indigo);
-    expect(app(ThemeManager::class)->getFilamentColors('default')['primary'])->toBe(Color::Amber);
+function setSiteTheme(string $theme): void
+{
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = $theme;
+    $settings->save();
 
-    // Panel registers without error using the theme-driven palette.
-    Filament::setCurrentPanel(Filament::getPanel('admin'));
-    expect(Filament::getPanel('admin'))->not->toBeNull();
+    // getSiteTheme() reads SiteSettings via the container; drop the cached
+    // ThemeManager instance so it re-resolves the (now-persisted) setting.
+    app()->forgetInstance(ThemeManager::class);
+}
+
+it('admin panel primary color follows the dark site theme', function () {
+    setSiteTheme('dark');
+
+    $colors = (new AdminPanelProvider(app()))->panel(Panel::make())->getColors();
+
+    expect($colors['primary'])->toBe(Color::Indigo);
+});
+
+it('admin panel primary color follows the default site theme', function () {
+    setSiteTheme('default');
+
+    $colors = (new AdminPanelProvider(app()))->panel(Panel::make())->getColors();
+
+    expect($colors['primary'])->toBe(Color::Amber);
+});
+
+it('app panel primary color follows the dark site theme', function () {
+    setSiteTheme('dark');
+
+    $colors = (new AppPanelProvider(app()))->panel(Panel::make())->getColors();
+
+    expect($colors['primary'])->toBe(Color::Indigo);
 });

--- a/tests/Feature/PanelThemeColorsTest.php
+++ b/tests/Feature/PanelThemeColorsTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use App\Services\ThemeManager;
+use Filament\Facades\Filament;
+use Filament\Support\Colors\Color;
+
+it('admin panel primary color follows the site theme', function () {
+    // getFilamentColors('dark') → Indigo; assert the resolver returns it so the
+    // panel provider (which passes this array to ->colors()) is driven by the theme.
+    expect(app(ThemeManager::class)->getFilamentColors('dark')['primary'])->toBe(Color::Indigo);
+    expect(app(ThemeManager::class)->getFilamentColors('default')['primary'])->toBe(Color::Amber);
+
+    // Panel registers without error using the theme-driven palette.
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    expect(Filament::getPanel('admin'))->not->toBeNull();
+});

--- a/tests/Feature/SiteSettingsActiveThemeTest.php
+++ b/tests/Feature/SiteSettingsActiveThemeTest.php
@@ -1,0 +1,7 @@
+<?php
+
+use App\Settings\SiteSettings;
+
+it('exposes active_theme defaulting to the default theme', function () {
+    expect(app(SiteSettings::class)->active_theme)->toBe('default');
+});

--- a/tests/Feature/ThemeSiteResolutionTest.php
+++ b/tests/Feature/ThemeSiteResolutionTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\User;
 use App\Services\ThemeManager;
 use App\Settings\SiteSettings;
 
@@ -23,4 +24,28 @@ it('lets a session preference win over the site theme', function () {
     $this->get('/');
 
     expect(app(ThemeManager::class)->getActiveTheme())->toBe('default');
+});
+
+it('falls through to the site theme when the user preference names a nonexistent theme', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'dark';
+    $settings->save();
+
+    $user = User::factory()->create(['theme_preference' => 'no-such-theme']);
+
+    $this->actingAs($user)->get('/');
+
+    expect(app(ThemeManager::class)->getActiveTheme())->toBe('dark');
+});
+
+it('lets a valid user preference win over the site theme', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'default';
+    $settings->save();
+
+    $user = User::factory()->create(['theme_preference' => 'dark']);
+
+    $this->actingAs($user)->get('/');
+
+    expect(app(ThemeManager::class)->getActiveTheme())->toBe('dark');
 });

--- a/tests/Feature/ThemeSiteResolutionTest.php
+++ b/tests/Feature/ThemeSiteResolutionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Services\ThemeManager;
+use App\Settings\SiteSettings;
+
+it('uses the site theme when no user or session preference is set', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'dark';
+    $settings->save();
+
+    // Re-boot the provider path by resolving a fresh ThemeManager via a request.
+    $this->get('/');
+
+    expect(app(ThemeManager::class)->getActiveTheme())->toBe('dark');
+});
+
+it('lets a session preference win over the site theme', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'dark';
+    $settings->save();
+
+    session(['theme_preference' => 'default']);
+    $this->get('/');
+
+    expect(app(ThemeManager::class)->getActiveTheme())->toBe('default');
+});

--- a/tests/Unit/ThemeManagerFilamentColorsTest.php
+++ b/tests/Unit/ThemeManagerFilamentColorsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use App\Services\ThemeManager;
+use Filament\Support\Colors\Color;
+
+it('maps the default theme primary color to the Amber Filament palette', function () {
+    $colors = app(ThemeManager::class)->getFilamentColors('default');
+
+    expect($colors)->toHaveKey('primary');
+    expect($colors['primary'])->toBe(Color::Amber);
+});
+
+it('maps the dark theme primary color to the Indigo Filament palette', function () {
+    $colors = app(ThemeManager::class)->getFilamentColors('dark');
+
+    expect($colors['primary'])->toBe(Color::Indigo);
+});
+
+it('falls back to Amber for an unknown color name', function () {
+    // A theme with no colors block resolves to the Amber default.
+    $colors = app(ThemeManager::class)->getFilamentColors('no-such-theme');
+
+    expect($colors['primary'])->toBe(Color::Amber);
+});

--- a/tests/Unit/ThemeManagerSiteThemeTest.php
+++ b/tests/Unit/ThemeManagerSiteThemeTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Services\ThemeManager;
+use App\Settings\SiteSettings;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('returns the persisted site theme', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'dark';
+    $settings->save();
+
+    expect(app(ThemeManager::class)->getSiteTheme())->toBe('dark');
+});
+
+it('falls back to config default when the site theme is unknown', function () {
+    $settings = app(SiteSettings::class);
+    $settings->active_theme = 'no-such-theme';
+    $settings->save();
+
+    expect(app(ThemeManager::class)->getSiteTheme())->toBe(config('theme.default'));
+});

--- a/tests/Unit/ThemeManagerTest.php
+++ b/tests/Unit/ThemeManagerTest.php
@@ -149,5 +149,5 @@ test('default theme has correct configuration', function () {
         ->and($config['name'])->toBe('default')
         ->and($config['label'])->toBe('Default Theme')
         ->and($config)->toHaveKey('colors')
-        ->and($config['colors']['primary'])->toBe('gray');
+        ->and($config['colors']['primary'])->toBe('amber');
 });

--- a/tests/Unit/ThemeManagerTest.php
+++ b/tests/Unit/ThemeManagerTest.php
@@ -2,6 +2,8 @@
 
 use App\Services\ThemeManager;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\View;
+use Illuminate\View\FileViewFinder;
 
 beforeEach(function () {
     $this->themeManager = new ThemeManager();
@@ -130,6 +132,29 @@ test('theme_views_path helper returns views path', function () {
 
     expect($path)->toBeString()
         ->and($path)->toContain('themes/default/views');
+});
+
+test('repeated setTheme calls do not grow the view finder paths', function () {
+    $finder = View::getFinder();
+
+    if (! $finder instanceof FileViewFinder) {
+        $this->markTestSkipped('View finder is not a FileViewFinder.');
+    }
+
+    $themeViewsPath = $this->themeManager->getThemeViewsPath('default');
+
+    for ($i = 0; $i < 5; $i++) {
+        $this->themeManager->setTheme('default');
+    }
+
+    $paths = $finder->getPaths();
+
+    expect(array_count_values($paths)[$themeViewsPath] ?? 0)->toBe(1);
+
+    $countAfterFirstCall = count($paths);
+    $this->themeManager->setTheme('default');
+
+    expect($finder->getPaths())->toHaveCount($countAfterFirstCall);
 });
 
 test('dark theme has correct configuration', function () {

--- a/themes/default/theme.json
+++ b/themes/default/theme.json
@@ -5,7 +5,7 @@
     "version": "1.0.0",
     "author": "Liberu Software",
     "colors": {
-        "primary": "gray",
+        "primary": "amber",
         "secondary": "slate"
     }
 }


### PR DESCRIPTION
## Summary

Admin-controlled **site-wide theme**, selectable from the Filament admin panel. All theming infrastructure already existed (`ThemeManager`, `ThemeServiceProvider`, per-user `ThemeSwitcher`, `themes/`); this adds the missing admin layer. Ships with the single `default` theme and **zero visual change** (default keeps the Amber primary).

Spec + plan: `docs/superpowers/specs/2026-07-01-admin-themes-design.md`, `docs/superpowers/plans/2026-07-01-admin-themes.md`.

## What changed

- **`SiteSettings.active_theme`** — new setting (spatie settings migration, default `default`), one source of truth.
- **Admin control** — "Appearance" section with a theme `Select` on the `ManageSiteSettings` page (options from `ThemeManager::getThemes()`).
- **`ThemeManager::getSiteTheme()`** — reads the setting, validated, never throws (safe under console/migrations).
- **`ThemeManager::getFilamentColors()`** — maps a theme's `theme.json` `colors.primary` → a Filament `Color` palette via an explicit whitelist (unknown → Amber).
- **Frontend resolution** — `user pref → session → site theme → config default`, each validated via `themeExists()`; re-derived per view render (ThemeManager is a boot-once singleton, stale under Octane).
- **Filament panels** — `AdminPanelProvider` + `AppPanelProvider` drive `->colors()` from the **site-wide** theme.
- **`phpunit.xml`** — fixed test `APP_KEY` (also cleared ~38 pre-existing `MissingAppKeyException` failures).

## Scope decisions

- Admin sets the site **default**; users may still override (frontend). Panels follow site-wide only.
- Filament restyling = **color palette** now; compiled per-theme Filament CSS deferred (reserved `theme.json` `filament_css` hook + `->viteTheme()`).

## Testing

TDD throughout. Full suite **219 passed / 0 failed / 12 pre-existing skips**; `pint` clean (174 files); PHPStan level 5 clean (61 files). Includes a regression test proving the per-render view-path registration is idempotent (no Octane view-path leak) and a panel-color test that asserts `Panel::getColors()` actually follows the site theme.

## Review

Each task independently reviewed; final whole-branch review (found + fixed an Octane view-path accumulation bug in `registerThemePaths()`).
