### PR TITLE
Restore UserResource and TeamResource for admin user management

### DIFF
--- a/app/Filament/Resources/TeamResource.php
+++ b/app/Filament/Resources/TeamResource.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\TeamResource\Pages\CreateTeam;
+use App\Filament\Resources\TeamResource\Pages\EditTeam;
+use App\Filament\Resources\TeamResource\Pages\ListTeams;
+use App\Models\Team;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class TeamResource extends Resource
+{
+    protected static ?string $model = Team::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-user-group';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Administration';
+
+    protected static ?string $navigationLabel = 'Teams';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /**
+     * Team is the tenant model itself — it has no team() relation to scope by.
+     */
+    public static function isScopedToTenant(): bool
+    {
+        return false;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                Select::make('user_id')
+                    ->label('Owner')
+                    ->relationship('owner', 'name')
+                    ->required()
+                    ->searchable()
+                    ->preload(),
+                Toggle::make('personal_team')
+                    ->label('Personal team'),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('owner.name')
+                    ->label('Owner')
+                    ->searchable()
+                    ->sortable(),
+                IconColumn::make('personal_team')
+                    ->boolean(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListTeams::route('/'),
+            'create' => CreateTeam::route('/create'),
+            'edit' => EditTeam::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/TeamResource/Pages/CreateTeam.php
+++ b/app/Filament/Resources/TeamResource/Pages/CreateTeam.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\TeamResource\Pages;
+
+use App\Filament\Resources\TeamResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateTeam extends CreateRecord
+{
+    protected static string $resource = TeamResource::class;
+}

--- a/app/Filament/Resources/TeamResource/Pages/EditTeam.php
+++ b/app/Filament/Resources/TeamResource/Pages/EditTeam.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\TeamResource\Pages;
+
+use App\Filament\Resources\TeamResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditTeam extends EditRecord
+{
+    protected static string $resource = TeamResource::class;
+
+    /**
+     * @return array<int, DeleteAction>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/TeamResource/Pages/ListTeams.php
+++ b/app/Filament/Resources/TeamResource/Pages/ListTeams.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\TeamResource\Pages;
+
+use App\Filament\Resources\TeamResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListTeams extends ListRecords
+{
+    protected static string $resource = TeamResource::class;
+
+    /**
+     * @return array<int, CreateAction>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource.php
+++ b/app/Filament/Resources/UserResource.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\UserResource\Pages\CreateUser;
+use App\Filament\Resources\UserResource\Pages\EditUser;
+use App\Filament\Resources\UserResource\Pages\ListUsers;
+use App\Models\User;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Illuminate\Support\Facades\Hash;
+
+class UserResource extends Resource
+{
+    protected static ?string $model = User::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-user-group';
+
+    protected static string|\UnitEnum|null $navigationGroup = 'Administration';
+
+    protected static ?string $navigationLabel = 'Users';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /**
+     * User's tenancy is owned + member teams (no single team() belongsTo),
+     * so the tenant panel can't scope the resource query to one team.
+     */
+    public static function isScopedToTenant(): bool
+    {
+        return false;
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('name')
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('email')
+                    ->email()
+                    ->required()
+                    ->unique(ignoreRecord: true)
+                    ->maxLength(255),
+                TextInput::make('password')
+                    ->password()
+                    ->dehydrateStateUsing(fn (string $state) => Hash::make($state))
+                    ->dehydrated(fn (?string $state) => filled($state))
+                    ->required(fn (string $operation) => $operation === 'create')
+                    ->maxLength(255)
+                    ->helperText('Leave blank to keep the current password.'),
+                DateTimePicker::make('email_verified_at')
+                    ->label('Email verified at'),
+                Select::make('roles')
+                    ->relationship('roles', 'name')
+                    ->multiple()
+                    ->preload()
+                    ->searchable(),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('email')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('roles.name')
+                    ->label('Roles')
+                    ->badge(),
+                IconColumn::make('email_verified_at')
+                    ->label('Verified')
+                    ->boolean()
+                    ->getStateUsing(fn (User $record): bool => $record->email_verified_at !== null),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListUsers::route('/'),
+            'create' => CreateUser::route('/create'),
+            'edit' => EditUser::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/CreateUser.php
+++ b/app/Filament/Resources/UserResource/Pages/CreateUser.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateUser extends CreateRecord
+{
+    protected static string $resource = UserResource::class;
+}

--- a/app/Filament/Resources/UserResource/Pages/EditUser.php
+++ b/app/Filament/Resources/UserResource/Pages/EditUser.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditUser extends EditRecord
+{
+    protected static string $resource = UserResource::class;
+
+    /**
+     * @return array<int, DeleteAction>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Filament\Resources\UserResource\Pages;
+
+use App\Filament\Resources\UserResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListUsers extends ListRecords
+{
+    protected static string $resource = UserResource::class;
+
+    /**
+     * @return array<int, CreateAction>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/tests/Feature/TeamResourceTest.php
+++ b/tests/Feature/TeamResourceTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Filament\Resources\TeamResource;
+use App\Filament\Resources\TeamResource\Pages\ListTeams;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('is not scoped to the team tenant (Team is the tenant itself)', function () {
+    expect(TeamResource::isScopedToTenant())->toBeFalse();
+});
+
+it('renders the teams list for a super admin', function () {
+    $admin = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $admin->id]);
+    $admin->forceFill(['current_team_id' => $team->id])->save();
+    $otherTeam = Team::factory()->create();
+
+    Gate::before(fn () => true);
+    $this->actingAs($admin);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($team);
+
+    Livewire::test(ListTeams::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$team, $otherTeam]);
+});

--- a/tests/Feature/UserResourceTest.php
+++ b/tests/Feature/UserResourceTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use App\Filament\Resources\UserResource;
+use App\Filament\Resources\UserResource\Pages\ListUsers;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('is not scoped to the team tenant (User has no team() relation)', function () {
+    expect(UserResource::isScopedToTenant())->toBeFalse();
+});
+
+it('renders the users list for a super admin', function () {
+    $team = Team::factory()->create();
+    $admin = User::factory()->create(['current_team_id' => $team->id]);
+    $other = User::factory()->create();
+
+    Gate::before(fn () => true);
+    $this->actingAs($admin);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($team);
+
+    Livewire::test(ListUsers::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords([$admin, $other]);
+});


### PR DESCRIPTION
## Summary
- The fresh-skeleton rebuild deleted `UserResource`, leaving super_admin with no way to manage users from `/admin` (only `ModuleResource`, `ManageSiteSettings`, Shield's `RoleResource` existed).
- Restores `UserResource` (recovered from the last pre-rebuild version at `10c4436a:app/Filament/Admin/Resources/Users/UserResource.php`, adapted to the current flat single-file resource style and Filament v5 API) with a trimmed, credible-default scope: name, email, password, email-verified-at, roles (Spatie/Shield).
- Adds `TeamResource` (no prior version existed — built fresh in the same style): name, owner, personal_team.
- Both resources override `isScopedToTenant(): false` — `User` has no `team()` relation (tenancy = owned + member teams) and `Team` is the tenant model itself, so the admin panel's `->tenant(Team::class)` scoping would otherwise 500 on either resource.

## Test plan
- [x] `tests/Feature/UserResourceTest.php` / `tests/Feature/TeamResourceTest.php` written first (confirmed RED: class-not-found), now GREEN — assert the tenancy opt-out and that each list page renders for a super admin.
- [x] Full suite: `vendor/bin/pest` → 0 failed, 12 skipped (pre-existing), 230 passed.
- [x] `vendor/bin/pint` clean on all changed files.
- [x] `vendor/bin/phpstan analyse` clean (level 5) on the new `app/Filament/Resources/**` files.