### PR TITLE
fix(shield): super_admin sees an empty admin panel — define via gate

### DIFF
--- a/config/filament-shield.php
+++ b/config/filament-shield.php
@@ -1,0 +1,267 @@
+<?php
+
+declare(strict_types=1);
+use BezhanSalleh\FilamentShield\Resources\Roles\RoleResource;
+use Filament\Pages\Dashboard;
+use Filament\Widgets\AccountWidget;
+use Filament\Widgets\FilamentInfoWidget;
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Shield Resource
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure the built-in role management resource. You can
+    | customize the URL, choose whether to show model paths, group it under
+    | a cluster, and decide which permission tabs to display.
+    |
+    */
+
+    'shield_resource' => [
+        'slug' => 'shield/roles',
+        'show_model_path' => true,
+        'cluster' => null,
+        'tabs' => [
+            'pages' => true,
+            'widgets' => true,
+            'resources' => true,
+            'custom_permissions' => false,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Multi-Tenancy
+    |--------------------------------------------------------------------------
+    |
+    | When your application supports teams, Shield will automatically detect
+    | and configure the tenant model during setup. This enables tenant-scoped
+    | roles and permissions throughout your application.
+    |
+    */
+
+    'tenant_model' => null,
+
+    /*
+    |--------------------------------------------------------------------------
+    | User Model
+    |--------------------------------------------------------------------------
+    |
+    | This value contains the class name of your user model. This model will
+    | be used for role assignments and must implement the HasRoles trait
+    | provided by the Spatie\Permission package.
+    |
+    */
+
+    'auth_provider_model' => 'App\\Models\\User',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Super Admin
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define a super admin that has unrestricted access to your
+    | application. You can choose to implement this via Laravel's gate system
+    | or as a traditional role with all permissions explicitly assigned.
+    |
+    */
+
+    'super_admin' => [
+        'enabled' => true,
+        'name' => 'super_admin',
+        'define_via_gate' => true,
+        'intercept_gate' => 'before',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Panel User
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, Shield will create a basic panel user role that can be
+    | assigned to users who should have access to your Filament panels but
+    | don't need any specific permissions beyond basic authentication.
+    |
+    */
+
+    'panel_user' => [
+        'enabled' => true,
+        'name' => 'panel_user',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Permission Builder
+    |--------------------------------------------------------------------------
+    |
+    | You can customize how permission keys are generated to match your
+    | preferred naming convention and organizational standards. Shield uses
+    | these settings when creating permission names from your resources.
+    |
+    | Supported formats: snake, kebab, pascal, camel, upper_snake, lower_snake
+    |
+    */
+
+    'permissions' => [
+        'separator' => ':',
+        'case' => 'pascal',
+        'generate' => true,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Policies
+    |--------------------------------------------------------------------------
+    |
+    | Shield can automatically generate Laravel policies for your resources.
+    | When merge is enabled, the methods below will be combined with any
+    | resource-specific methods you define in the resources section.
+    |
+    */
+
+    'policies' => [
+        'path' => app_path('Policies'),
+        'merge' => true,
+        'generate' => true,
+        'methods' => [
+            'viewAny', 'view', 'create', 'update', 'delete', 'deleteAny', 'restore',
+            'forceDelete', 'forceDeleteAny', 'restoreAny', 'replicate', 'reorder',
+        ],
+        'single_parameter_methods' => [
+            'viewAny',
+            'create',
+            'deleteAny',
+            'forceDeleteAny',
+            'restoreAny',
+            'reorder',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Localization
+    |--------------------------------------------------------------------------
+    |
+    | Shield supports multiple languages out of the box. When enabled, you
+    | can provide translated labels for permissions to create a more
+    | localized experience for your international users.
+    |
+    */
+
+    'localization' => [
+        'enabled' => false,
+        'key' => 'filament-shield::filament-shield.resource_permission_prefixes_labels',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resources
+    |--------------------------------------------------------------------------
+    |
+    | Here you can fine-tune permissions for specific Filament resources.
+    | Use the 'manage' array to override the default policy methods for
+    | individual resources, giving you granular control over permissions.
+    |
+    */
+
+    'resources' => [
+        'subject' => 'model',
+        'manage' => [
+            RoleResource::class => [
+                'viewAny',
+                'view',
+                'create',
+                'update',
+                'delete',
+            ],
+        ],
+        'exclude' => [
+            //
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pages
+    |--------------------------------------------------------------------------
+    |
+    | Most Filament pages only require view permissions. Pages listed in the
+    | exclude array will be skipped during permission generation and won't
+    | appear in your role management interface.
+    |
+    */
+
+    'pages' => [
+        'subject' => 'class',
+        'prefix' => 'view',
+        'exclude' => [
+            Dashboard::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Widgets
+    |--------------------------------------------------------------------------
+    |
+    | Like pages, widgets typically only need view permissions. Add widgets
+    | to the exclude array if you don't want them to appear in your role
+    | management interface.
+    |
+    */
+
+    'widgets' => [
+        'subject' => 'class',
+        'prefix' => 'view',
+        'exclude' => [
+            AccountWidget::class,
+            FilamentInfoWidget::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Permissions
+    |--------------------------------------------------------------------------
+    |
+    | Sometimes you need permissions that don't map to resources, pages, or
+    | widgets. Define any custom permissions here and they'll be available
+    | when editing roles in your application.
+    |
+    */
+
+    'custom_permissions' => [],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Entity Discovery
+    |--------------------------------------------------------------------------
+    |
+    | By default, Shield only looks for entities in your default Filament
+    | panel. Enable these options if you're using multiple panels and want
+    | Shield to discover entities across all of them.
+    |
+    */
+
+    'discovery' => [
+        'discover_all_resources' => false,
+        'discover_all_widgets' => false,
+        'discover_all_pages' => false,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Role Policy
+    |--------------------------------------------------------------------------
+    |
+    | Shield can automatically register a policy for role management itself.
+    | This lets you control who can manage roles using Laravel's built-in
+    | authorization system. Requires a RolePolicy class in your app.
+    |
+    */
+
+    'register_role_policy' => true,
+
+];

--- a/tests/Feature/SuperAdminAccessTest.php
+++ b/tests/Feature/SuperAdminAccessTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+
+uses(RefreshDatabase::class);
+
+// A fresh install generates no Shield permissions, so a super_admin only sees
+// resources if it BYPASSES policies via Shield's gate (define_via_gate). Without
+// that, the admin panel is empty. This locks the gate on.
+
+it('defines the super admin via gate so it bypasses policies', function () {
+    expect(config('filament-shield.super_admin.define_via_gate'))->toBeTrue();
+});
+
+it('lets a super_admin view resources even with no permissions generated', function () {
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->id]);
+    setPermissionsTeamId($team->id);
+    Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web', 'team_id' => $team->id]);
+    $user->assignRole('super_admin');
+    $user->unsetRelation('roles');
+
+    // No permissions exist (shield:generate not run); visibility must come from the gate.
+    expect(Permission::count())->toBe(0);
+    expect($user->can('viewAny', User::class))->toBeTrue();
+});


### PR DESCRIPTION
## Problem

After logging in as super_admin, the **admin panel is empty** — no Users, Teams, Roles, Modules, or Posts in the nav, even though all five resources register correctly.

## Root cause (investigated, not guessed)

On a fresh install:
- `shield:generate` is never run → **0 permissions exist**.
- `config/filament-shield.php` is **unpublished**, so `super_admin.define_via_gate` defaults to **`false`** → Shield never registers its super-admin `Gate::before`.

Result: the `super_admin` role has no permissions *and* doesn't bypass policies, so every Filament resource's `viewAny` is denied → empty nav. Verified live: all 5 resources register, the admin user genuinely holds `super_admin` in its team, yet `can('viewAny', User::class)` returned `false`; `gate_before_hit` was `false`. Confirmed the fix by injecting the exact gate Shield uses (`$user->hasRole('super_admin') ? true : null`) → `viewAny` flipped to `true`.

This is a pre-existing Shield setup gap (documented in CLAUDE.md's tenancy notes), not caused by the recent module/user-management work — those resources register fine.

## Fix

Publish `config/filament-shield.php` and set `super_admin.define_via_gate = true`. Shield's `FilamentShieldServiceProvider` then registers `Gate::before(fn => hasRole('super_admin') ? true : null)`, so super_admin bypasses all policies and sees everything out of the box — no `shield:generate` step required. (The `TeamsPermission` middleware sets the team context before the gate runs, so the team-scoped `hasRole` resolves on real requests.)

Chosen over "run shield:generate + grant super_admin all perms" because a boilerplate should have a working super admin immediately after `migrate:fresh --seed`; non-super roles can still be granted granular permissions via `shield:generate` when needed.

## Testing

TDD: `tests/Feature/SuperAdminAccessTest.php` asserts (1) `define_via_gate` is true, (2) a super_admin can `viewAny` a resource with **zero** permissions generated (RED before the config change, GREEN after). Full suite **248 passed / 0 failed**; phpstan level 9 clean.
