### PR TITLE
fix(shield): super_admin still saw an empty admin panel — team-agnostic bypass gate

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -156,6 +156,28 @@ class User extends Authenticatable implements FilamentUser, HasDefaultTenant, Ha
             ->exists();
     }
 
+    /**
+     * True if the user holds the super_admin role in ANY team. Team-agnostic
+     * (unlike Spatie's team-scoped hasRole), so it drives the policy-bypass gate
+     * reliably even when no team context is set on the request.
+     */
+    public function isSuperAdmin(): bool
+    {
+        /** @var string $pivot */
+        $pivot = config('permission.table_names.model_has_roles', 'model_has_roles');
+        /** @var string $roles */
+        $roles = config('permission.table_names.roles', 'roles');
+        /** @var string $superAdmin */
+        $superAdmin = config('filament-shield.super_admin.name', 'super_admin');
+
+        return DB::table($pivot)
+            ->join($roles, "{$roles}.id", '=', "{$pivot}.role_id")
+            ->where("{$pivot}.model_id", $this->getKey())
+            ->where("{$pivot}.model_type", $this->getMorphClass())
+            ->where("{$roles}.name", $superAdmin)
+            ->exists();
+    }
+
     public function getDefaultTenant(Panel $panel): ?Model
     {
         return $this->latestTeam;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -21,6 +21,13 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        // Super admins bypass every policy, regardless of the active team context.
+        // Shield's define_via_gate uses team-scoped hasRole(), which returns false
+        // when no team is set on the request (Filament nav renders before the tenant
+        // team is synced) — leaving the admin panel empty. isSuperAdmin() checks the
+        // role across all teams, so the bypass is reliable.
+        Gate::before(fn (User $user): ?bool => $user->isSuperAdmin() ? true : null);
+
         // Gate the Pulse dashboard to admins (Telescope has its own gate).
         Gate::define('viewPulse', fn (User $user) => $user->isAdmin());
     }

--- a/tests/Feature/SuperAdminGateTeamAgnosticTest.php
+++ b/tests/Feature/SuperAdminGateTeamAgnosticTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Blog\Models\Post;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\PermissionRegistrar;
+
+uses(RefreshDatabase::class);
+
+// Shield's define_via_gate uses team-scoped hasRole(), which returns false when
+// no team context is set during a request — the super_admin then sees an empty
+// admin panel. Visibility must not depend on the team context being set.
+
+function makeSuperAdmin(): User
+{
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->id]);
+    $user->forceFill(['current_team_id' => $team->id])->save();
+    setPermissionsTeamId($team->id);
+    Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web', 'team_id' => $team->id]);
+    $user->assignRole('super_admin');
+    $user->unsetRelation('roles');
+
+    return $user;
+}
+
+it('detects super_admin regardless of the active team context', function () {
+    $user = makeSuperAdmin();
+
+    app(PermissionRegistrar::class)->setPermissionsTeamId(null); // simulate a request with no team context
+
+    expect($user->isSuperAdmin())->toBeTrue();
+});
+
+it('lets a super_admin view resources with NO team context set', function () {
+    $user = makeSuperAdmin();
+
+    app(PermissionRegistrar::class)->setPermissionsTeamId(null); // the failing production case
+
+    expect($user->can('viewAny', User::class))->toBeTrue();
+    expect($user->can('viewAny', Post::class))->toBeTrue();
+});


### PR DESCRIPTION
## Problem

Even after #593 (which set `super_admin.define_via_gate = true`), the **admin panel is still empty** for a super_admin.

## Root cause (why #593 wasn't enough)

Shield's `define_via_gate` registers `Gate::before(fn ($u) => $u->hasRole('super_admin') ? true : null)` — but `hasRole()` is **team-scoped** (Spatie `teams => true`). This app has no middleware guaranteeing the permissions team context is set when the gate fires: only `SyncShieldTenant` runs, in `tenantMiddleware`, *after* tenant resolution — but Filament evaluates each resource's `viewAny` while building the nav, when the team context can still be **null**.

Reproduced: with `getPermissionsTeamId()` null, `hasRole('super_admin')` = `false` → gate returns null → policies deny → `can('viewAny', User)` = `false` → empty nav. The role genuinely exists (in team 1), it's just invisible without the right team context.

## Fix

Register a **team-agnostic** `Gate::before` in `AppServiceProvider`, keyed on a new `User::isSuperAdmin()` that checks the `super_admin` role across **all** teams (direct pivot query, like the existing `hasAdminAccess()`). The bypass no longer depends on the active team context, so super_admin sees everything on every request.

`#593`'s `define_via_gate=true` is left in place (harmless — Shield's team-scoped gate is now just a redundant second grant); this gate is the reliable one.

## Verified

- Reproduced the failure (null team context → `viewAny` false), then confirmed the fix (`isSuperAdmin` true, `viewAny` User + Post true) both in a test and live against the seeded `admin@example.com`.
- TDD: `tests/Feature/SuperAdminGateTeamAgnosticTest.php` asserts super_admin `viewAny` **with no team context set** (the production case) — RED before, GREEN after.
- Full suite **250 passed / 0 failed**; Pint clean; PHPStan level 9 clean.

## To see it

Merge, then `docker compose exec php-fpm php artisan config:clear` (in case config is cached) and reload `/admin` — all resources (Users, Teams, Roles, Modules, Posts) now show.
