### PR TITLE
fix(seeder): admin owns the Default team (drop placeholder owner)

### DIFF
--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -29,8 +29,21 @@ class UserSeeder extends Seeder
         );
 
         $team = Team::firstOrFail();
+
+        // TeamSeeder runs first and may have created a throwaway owner to satisfy
+        // the team's user_id. Hand ownership to the admin and drop that placeholder.
+        $placeholderOwnerId = $team->user_id;
+        $team->forceFill(['user_id' => $adminUser->id])->save();
+
         $adminUser->teams()->syncWithoutDetaching([$team->id]);
         $adminUser->forceFill(['current_team_id' => $team->id])->save();
+
+        if ($placeholderOwnerId !== null && $placeholderOwnerId !== $adminUser->id) {
+            User::where('id', $placeholderOwnerId)
+                ->where('email', 'owner@example.com')
+                ->whereDoesntHave('ownedTeams')
+                ->delete();
+        }
 
         // Assign the role in the team's permission context (team-scoped roles).
         if (Utils::isTenancyEnabled()) {

--- a/tests/Feature/SeederAdminOwnershipTest.php
+++ b/tests/Feature/SeederAdminOwnershipTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolesSeeder;
+use Database\Seeders\TeamSeeder;
+use Database\Seeders\UserSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use function Pest\Laravel\seed;
+
+uses(RefreshDatabase::class);
+
+it('makes admin@example.com the owner of the Default team', function () {
+    seed(TeamSeeder::class);
+    seed(RolesSeeder::class);
+    seed(UserSeeder::class);
+
+    $admin = User::where('email', 'admin@example.com')->firstOrFail();
+    $team = Team::where('name', 'Default')->firstOrFail();
+
+    expect($team->user_id)->toBe($admin->id);
+    expect($admin->current_team_id)->toBe($team->id);
+});
+
+it('leaves no throwaway owner@example.com placeholder user', function () {
+    seed(TeamSeeder::class);
+    seed(RolesSeeder::class);
+    seed(UserSeeder::class);
+
+    expect(User::where('email', 'owner@example.com')->exists())->toBeFalse();
+});


### PR DESCRIPTION
## Problem

On a fresh `migrate:fresh --seed`, `TeamSeeder` runs before `UserSeeder` with an empty users table, so it creates a throwaway `owner@example.com` to satisfy the team's `user_id`. Result: `admin@example.com` was only a **member** of the Default team, and a purposeless placeholder user lingered.

## Fix

`UserSeeder` now hands Default-team ownership to the admin and deletes the placeholder (guarded: only `owner@example.com`, only if it owns no teams). A fresh seed yields **one** user — the super_admin — owning the Default team.

## Verified

Fresh seed: `admin_owns_team=true`, placeholder `gone`, `total_users=1`, `isSuperAdmin=true`, `viewAny` (null team context) `true` — admin sees everything. TDD test `SeederAdminOwnershipTest` (RED→GREEN). Full suite **252 passed / 0 failed**; Pint clean.