### PR TITLE
fix(admin): admin panel 500 — Role has no team() relation (Shield RoleResource tenancy)

### DIFF
--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -8,7 +8,6 @@ use App\Models\Team;
 use App\Services\ThemeManager;
 use BezhanSalleh\FilamentShield\FilamentShieldPlugin;
 use BezhanSalleh\FilamentShield\Middleware\SyncShieldTenant;
-use BezhanSalleh\FilamentShield\Support\Utils;
 use Filament\Http\Middleware\Authenticate;
 use Filament\Http\Middleware\AuthenticateSession;
 use Filament\Http\Middleware\DisableBladeIconComponents;
@@ -62,11 +61,13 @@ class AdminPanelProvider extends PanelProvider
                 SetLocale::class,
             ])
             ->plugins([
-                // Roles are team-scoped only when Spatie teams are enabled; gating on
-                // Utils::isTenancyEnabled() keeps Shield's RoleResource from resolving a
-                // missing Role->team() relation (which would 500 the tenant panel).
+                // Do NOT tenant-scope Shield's RoleResource: the admin panel scopes by
+                // an ownershipRelationship of 'team', but App\Models\Role (Spatie) has no
+                // team() relation, so scoping it 500s the panel when the nav/badges render.
+                // Roles are already team-isolated by Spatie's team_id column; leave the
+                // resource unscoped (like every other resource here overrides isScopedToTenant).
                 FilamentShieldPlugin::make()
-                    ->scopeToTenant(Utils::isTenancyEnabled()),
+                    ->scopeToTenant(false),
                 ModuleFilamentPlugin::make()->for('Admin'),
             ])
             ->authMiddleware([

--- a/tests/Feature/AdminPanelRendersTest.php
+++ b/tests/Feature/AdminPanelRendersTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+it('renders the full admin panel for a super_admin without the Role team() error', function () {
+    $admin = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $admin->id]);
+    $admin->forceFill(['current_team_id' => $team->id])->save();
+    setPermissionsTeamId($team->id);
+    Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web', 'team_id' => $team->id]);
+    $admin->assignRole('super_admin');
+
+    // Full HTTP render (navigation + badges), not a single Livewire component.
+    $this->actingAs($admin)
+        ->get(Filament::getPanel('admin')->getUrl($team))
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Problem

Logging in and visiting `/admin/{tenant}` 500s:

> The model [App\Models\Role] does not have a relationship named [team].

## Root cause

The admin panel is `->tenant(Team::class, ownershipRelationship: 'team')`, so tenant-scoped resources are filtered via a `team` relationship on their model. `FilamentShieldPlugin` was set `->scopeToTenant(Utils::isTenancyEnabled())` — which is **`true`** — so Shield's `RoleResource` gets tenant-scoped, but `App\Models\Role` (Spatie) has **no `team()` relation** → 500 when the panel renders (nav badge counts tenant-scoped roles).

An existing test rendered `ListRoles` via `Livewire::test` and passed — it skips the full nav/badge build, so it never hit the failing path. Reproduced here with a full HTTP render.

## Fix

`->scopeToTenant(false)`. Roles are already isolated by Spatie's `team_id` column; RoleResource joins every other resource in this panel that isn't record-scoped. Removed the now-unused `Utils` import.

## Verified

New `AdminPanelRendersTest` does a full `GET` of the admin panel as a super_admin — RED (the exact error) before, GREEN after. Full suite **253 passed / 0 failed**; Pint + PHPStan L9 clean.