### PR TITLE
feat(auth): super_admins land on /admin after login

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,13 +1,25 @@
 <?php
 
+use App\Models\User;
+use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
 });
 
-// Authenticated home — users land in the Filament "app" panel (user-facing surface).
+// Authenticated home — super admins land in the "admin" panel, everyone else in
+// the user-facing "app" panel.
 Route::get('/dashboard', function () {
+    $user = auth()->user();
+
+    if ($user instanceof User && $user->isSuperAdmin()) {
+        $panel = Filament::getPanel('admin');
+        $tenant = $user->getDefaultTenant($panel);
+
+        return redirect($tenant !== null ? $panel->getUrl($tenant) : '/'.$panel->getPath());
+    }
+
     return redirect()->route('filament.app.pages.dashboard');
 })->middleware(['auth:sanctum', config('jetstream.auth_session')])->name('dashboard');
 

--- a/tests/Feature/LoginLandingRedirectTest.php
+++ b/tests/Feature/LoginLandingRedirectTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function seedTeamUser(bool $superAdmin): User
+{
+    $user = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $user->id]);
+    $user->forceFill(['current_team_id' => $team->id])->save();
+
+    if ($superAdmin) {
+        setPermissionsTeamId($team->id);
+        Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web', 'team_id' => $team->id]);
+        $user->assignRole('super_admin');
+    }
+
+    return $user;
+}
+
+it('sends a super_admin to the admin panel after login', function () {
+    $admin = seedTeamUser(superAdmin: true);
+
+    $this->actingAs($admin)
+        ->get('/dashboard')
+        ->assertRedirectContains('/admin');
+});
+
+it('sends a normal user to the app panel after login', function () {
+    $user = seedTeamUser(superAdmin: false);
+
+    $this->actingAs($user)
+        ->get('/dashboard')
+        ->assertRedirect(route('filament.app.pages.dashboard'));
+});


### PR DESCRIPTION
## Change

The `dashboard` route (authenticated home) redirected **everyone** to the app panel (`/app`). Now:
- **super_admin** → the admin panel at their default tenant (`/admin/{team}`)
- **everyone else** → `/app` (unchanged)

Uses the team-agnostic `User::isSuperAdmin()` (added in #594) and `getDefaultTenant()` to resolve the admin tenant URL, falling back to the panel path if no tenant.

## Testing

TDD: `LoginLandingRedirectTest` — super_admin `/dashboard` → `/admin`, normal user → app panel dashboard (RED→GREEN). Full suite **254 passed / 0 failed**; Pint + PHPStan L9 clean.

Pairs with #596 (which fixes the /admin 500) — merge #596 first.