### PR TITLE
fix(blog): creating a post 500'd — set author (user_id) on create

### DIFF
--- a/app/Modules/Blog/Filament/Admin/Resources/PostResource/Pages/CreatePost.php
+++ b/app/Modules/Blog/Filament/Admin/Resources/PostResource/Pages/CreatePost.php
@@ -8,4 +8,18 @@ use Filament\Resources\Pages\CreateRecord;
 class CreatePost extends CreateRecord
 {
     protected static string $resource = PostResource::class;
+
+    /**
+     * Posts belong to an author (user_id is NOT NULL and not on the form),
+     * so default it to the acting user.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        $data['user_id'] ??= auth()->id();
+
+        return $data;
+    }
 }

--- a/tests/Feature/Modules/BlogPostAuthorTest.php
+++ b/tests/Feature/Modules/BlogPostAuthorTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use App\Modules\Blog\Filament\Admin\Resources\PostResource\Pages\CreatePost;
+use App\Modules\Blog\Models\Post;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('assigns the acting user as author when creating a post (user_id has no default)', function () {
+    $admin = User::factory()->create();
+    $team = Team::factory()->create(['user_id' => $admin->id]);
+    $admin->forceFill(['current_team_id' => $team->id])->save();
+    setPermissionsTeamId($team->id);
+    Role::firstOrCreate(['name' => 'super_admin', 'guard_name' => 'web', 'team_id' => $team->id]);
+    $admin->assignRole('super_admin');
+
+    $this->actingAs($admin);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+    Filament::setTenant($team);
+
+    Livewire::test(CreatePost::class)
+        ->fillForm([
+            'title' => 'Hello World',
+            'slug' => 'hello-world',
+            'body' => 'First post.',
+            'status' => 'published',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $post = Post::firstOrFail();
+    expect($post->user_id)->toBe($admin->id);
+});


### PR DESCRIPTION
## Problem

Creating a post in the admin panel:

> SQLSTATE[HY000]: General error: 1364 Field 'user_id' doesn't have a default value

## Root cause

`module_blog_posts.user_id` is `foreignId()->constrained()` (NOT NULL, no default), and it isn't a field on the `PostResource` form, so nothing populated it on create.

## Fix

`CreatePost::mutateFormDataBeforeCreate` defaults `user_id` to the acting user (`auth()->id()`), so the creating admin becomes the author. Uses `??=` so an explicit value (e.g. a future author picker) is respected.

## Testing

TDD: `BlogPostAuthorTest` creates a post through `CreatePost` via Livewire and asserts no form errors + `user_id` = the acting admin (RED — the exact SQL error — before, GREEN after). Full suite **256 passed / 0 failed**; Pint + PHPStan L9 clean.