### PR TITLE
fix(search): require auth + stop leaking drafts and private/restricted groups

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -114,7 +114,6 @@ class SearchController extends Controller
             'author_id' => 'nullable|integer|exists:users,id',
             'published_from' => 'nullable|date',
             'published_to' => 'nullable|date',
-            'include_drafts' => 'nullable|boolean',
             'order_by' => 'nullable|in:title,published_at,created_at',
             'order_direction' => 'nullable|in:asc,desc',
             'per_page' => 'nullable|integer|min:1|max:100',
@@ -130,7 +129,6 @@ class SearchController extends Controller
     {
         return $request->validate([
             'query' => 'nullable|string|max:255',
-            'type' => 'nullable|in:public,private,restricted',
             'active_only' => 'nullable|boolean',
             'owner_id' => 'nullable|integer|exists:users,id',
             'created_from' => 'nullable|date',

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -87,10 +87,8 @@ class SearchService
             );
         }
 
-        // Only published posts (unless explicitly requesting all)
-        if (! isset($filters['include_drafts']) || ! $filters['include_drafts']) {
-            $query->published();
-        }
+        // Drafts must never be reachable via search, regardless of caller input.
+        $query->published();
 
         // Order by
         $orderBy = $this->toString($filters['order_by'] ?? 'published_at');
@@ -120,10 +118,8 @@ class SearchService
             $query->active();
         }
 
-        // Filter by type
-        if (! empty($filters['type'])) {
-            $query->type($this->toString($filters['type']));
-        }
+        // Only public groups are searchable; private/restricted must never appear.
+        $query->type('public');
 
         // Filter by owner
         if (! empty($filters['owner_id'])) {

--- a/routes/api.php
+++ b/routes/api.php
@@ -5,7 +5,7 @@ use App\Http\Controllers\MessageController;
 use Illuminate\Support\Facades\Route;
 
 // Search API routes
-Route::prefix('search')->name('search.')->middleware('throttle:60,1')->group(function () {
+Route::prefix('search')->name('search.')->middleware(['auth:sanctum', 'throttle:60,1'])->group(function () {
     Route::get('/users', [SearchController::class, 'users'])->name('users');
     Route::get('/posts', [SearchController::class, 'posts'])->name('posts');
     Route::get('/groups', [SearchController::class, 'groups'])->name('groups');

--- a/tests/Feature/SearchAllTest.php
+++ b/tests/Feature/SearchAllTest.php
@@ -32,6 +32,8 @@ beforeEach(function () {
         'owner_id' => $this->user->id,
         'type' => 'public',
     ]);
+
+    $this->actingAs($this->user, 'sanctum');
 });
 
 it('can search all entities with a query', function () {

--- a/tests/Feature/SearchApiSecurityTest.php
+++ b/tests/Feature/SearchApiSecurityTest.php
@@ -82,4 +82,20 @@ describe('non-public groups stay hidden', function () {
 
         expect($response->json('data.0.id'))->toBe($public->id);
     });
+
+    it('cannot be coerced to return private groups via a type param', function () {
+        $public = Group::create(['name' => 'Public Group', 'description' => 'x', 'owner_id' => $this->user->id, 'type' => 'public']);
+        Group::create(['name' => 'Private Group', 'description' => 'x', 'owner_id' => $this->user->id, 'type' => 'private']);
+
+        // The dropped `type` param must not resurrect private groups (regression guard).
+        foreach (['private', 'restricted'] as $type) {
+            $response = $this->actingAs($this->user, 'sanctum')
+                ->getJson('/api/search/groups?type='.$type);
+
+            $response->assertStatus(200)
+                ->assertJsonMissing(['name' => 'Private Group'])
+                ->assertJsonCount(1, 'data');
+            expect($response->json('data.0.id'))->toBe($public->id);
+        }
+    });
 });

--- a/tests/Feature/SearchApiSecurityTest.php
+++ b/tests/Feature/SearchApiSecurityTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use App\Models\Group;
+use App\Models\Post;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    $this->user = User::factory()->create();
+});
+
+describe('unauthenticated access', function () {
+    it('rejects unauthenticated users search', function () {
+        $this->getJson('/api/search/users')->assertStatus(401);
+    });
+
+    it('rejects unauthenticated posts search', function () {
+        $this->getJson('/api/search/posts')->assertStatus(401);
+    });
+
+    it('rejects unauthenticated groups search', function () {
+        $this->getJson('/api/search/groups')->assertStatus(401);
+    });
+
+    it('rejects unauthenticated all search', function () {
+        $this->getJson('/api/search/all')->assertStatus(401);
+    });
+});
+
+describe('draft posts stay hidden', function () {
+    it('never returns a draft even with include_drafts=1', function () {
+        Post::create([
+            'title' => 'Secret Draft',
+            'content' => 'Not for public eyes',
+            'user_id' => $this->user->id,
+            'status' => 'draft',
+            'published_at' => null,
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson('/api/search/posts?include_drafts=1&status=draft');
+
+        $response->assertStatus(200)
+            ->assertJsonMissing(['title' => 'Secret Draft'])
+            ->assertJsonCount(0, 'data');
+    });
+});
+
+describe('non-public groups stay hidden', function () {
+    it('excludes private and restricted groups but returns public ones', function () {
+        $public = Group::create([
+            'name' => 'Public Group',
+            'description' => 'Anyone can see this',
+            'owner_id' => $this->user->id,
+            'type' => 'public',
+        ]);
+
+        Group::create([
+            'name' => 'Private Group',
+            'description' => 'Members only',
+            'owner_id' => $this->user->id,
+            'type' => 'private',
+        ]);
+
+        Group::create([
+            'name' => 'Restricted Group',
+            'description' => 'Invite only',
+            'owner_id' => $this->user->id,
+            'type' => 'restricted',
+        ]);
+
+        $response = $this->actingAs($this->user, 'sanctum')
+            ->getJson('/api/search/groups');
+
+        $response->assertStatus(200)
+            ->assertJsonMissing(['name' => 'Private Group'])
+            ->assertJsonMissing(['name' => 'Restricted Group'])
+            ->assertJsonFragment(['name' => 'Public Group'])
+            ->assertJsonCount(1, 'data');
+
+        expect($response->json('data.0.id'))->toBe($public->id);
+    });
+});

--- a/tests/Feature/SearchGroupsTest.php
+++ b/tests/Feature/SearchGroupsTest.php
@@ -41,6 +41,8 @@ beforeEach(function () {
         'owner_id' => $this->user1->id,
         'type' => 'restricted',
     ]);
+
+    $this->actingAs($this->user1, 'sanctum');
 });
 
 it('can search groups by name', function () {
@@ -51,15 +53,16 @@ it('can search groups by name', function () {
         ->assertJsonFragment(['name' => 'Laravel Community']);
 });
 
-it('can search groups by description', function () {
+it('does not search private groups by description', function () {
+    // "Private Beta Testers" matches the query but is a private group, so search must
+    // not surface it — only public groups are searchable.
     $response = $this->getJson('/api/search/groups?query=beta');
 
     $response->assertStatus(200)
-        ->assertJsonCount(1, 'data')
-        ->assertJsonFragment(['name' => 'Private Beta Testers']);
+        ->assertJsonCount(0, 'data');
 });
 
-it('can filter groups by type', function () {
+it('only ever returns public groups regardless of the type param', function () {
     $response = $this->getJson('/api/search/groups?type=public');
 
     $response->assertStatus(200)
@@ -67,21 +70,19 @@ it('can filter groups by type', function () {
         ->assertJsonFragment(['type' => 'public']);
 });
 
-it('can filter groups by owner', function () {
+it('can filter groups by owner, excluding their non-public groups', function () {
+    // user1 owns group1 (public) and group3 (restricted) — only the public one may appear.
     $response = $this->getJson('/api/search/groups?owner_id='.$this->user1->id);
 
     $response->assertStatus(200)
-        ->assertJsonCount(2, 'data');
-
-    $data = $response->json('data');
-    foreach ($data as $group) {
-        expect($group['owner_id'])->toBe($this->user1->id);
-    }
+        ->assertJsonCount(1, 'data')
+        ->assertJsonFragment(['name' => 'Laravel Community']);
 });
 
 it('can filter groups by creation date range', function () {
-    // Update group creation dates for testing
-    $this->group1->forceFill(['created_at' => now()->subDays(10)])->saveQuietly();
+    // Only group1 is public; put it in range and leave the others out of scope entirely
+    // since they're private/restricted and must never be returned regardless of dates.
+    $this->group1->forceFill(['created_at' => now()->subDays(3)])->saveQuietly();
     $this->group2->forceFill(['created_at' => now()->subDays(5)])->saveQuietly();
     $this->group3->forceFill(['created_at' => now()->subDay()])->saveQuietly();
 
@@ -91,16 +92,24 @@ it('can filter groups by creation date range', function () {
     $response = $this->getJson("/api/search/groups?created_from={$from}&created_to={$to}");
 
     $response->assertStatus(200)
-        ->assertJsonCount(2, 'data');
+        ->assertJsonCount(1, 'data')
+        ->assertJsonFragment(['name' => 'Laravel Community']);
 });
 
 it('can sort groups by name', function () {
+    Group::create([
+        'name' => 'Alpha Group',
+        'description' => 'Another public group for sort testing',
+        'owner_id' => $this->user2->id,
+        'type' => 'public',
+    ]);
+
     $response = $this->getJson('/api/search/groups?order_by=name&order_direction=asc');
 
     $response->assertStatus(200);
 
     $names = collect($response->json('data'))->pluck('name')->all();
-    expect($names[0])->toBe('Admin Team');
+    expect($names[0])->toBe('Alpha Group');
 });
 
 it('can paginate groups', function () {
@@ -127,13 +136,6 @@ it('can paginate groups', function () {
         ]);
 });
 
-it('validates group search type', function () {
-    $response = $this->getJson('/api/search/groups?type=invalid');
-
-    $response->assertStatus(422)
-        ->assertJsonValidationErrors(['type']);
-});
-
 it('validates owner_id exists', function () {
     $response = $this->getJson('/api/search/groups?owner_id=99999');
 
@@ -142,11 +144,11 @@ it('validates owner_id exists', function () {
 });
 
 it('can combine multiple group filters', function () {
-    $response = $this->getJson('/api/search/groups?query=admin&type=restricted&owner_id='.$this->user1->id);
+    $response = $this->getJson('/api/search/groups?query=Laravel&owner_id='.$this->user1->id);
 
     $response->assertStatus(200)
         ->assertJsonCount(1, 'data')
-        ->assertJsonFragment(['name' => 'Admin Team']);
+        ->assertJsonFragment(['name' => 'Laravel Community']);
 });
 
 it('returns groups with owner relationship', function () {

--- a/tests/Feature/SearchPostsTest.php
+++ b/tests/Feature/SearchPostsTest.php
@@ -46,6 +46,8 @@ beforeEach(function () {
         'status' => 'draft',
         'published_at' => null,
     ]);
+
+    $this->actingAs($this->user1, 'sanctum');
 });
 
 it('can search posts by title', function () {
@@ -64,12 +66,11 @@ it('can search posts by content', function () {
         ->assertJsonFragment(['title' => 'Advanced PHP']);
 });
 
-it('can filter posts by status', function () {
+it('never returns drafts, even with status=draft&include_drafts=1', function () {
     $response = $this->getJson('/api/search/posts?status=draft&include_drafts=1');
 
     $response->assertStatus(200)
-        ->assertJsonCount(1, 'data')
-        ->assertJsonFragment(['status' => 'draft']);
+        ->assertJsonCount(0, 'data');
 });
 
 it('excludes draft posts by default', function () {

--- a/tests/Feature/SearchTest.php
+++ b/tests/Feature/SearchTest.php
@@ -8,6 +8,10 @@ use Illuminate\Support\Facades\Cache;
 
 uses(RefreshDatabase::class);
 
+beforeEach(function () {
+    $this->actingAs(User::factory()->create(), 'sanctum');
+});
+
 describe('User Search', function () {
     it('can search users by name', function () {
         User::factory()->create(['name' => 'John Doe', 'email' => 'john@example.com']);
@@ -127,8 +131,8 @@ describe('Post Search', function () {
 describe('Group Search', function () {
     it('can search groups by name', function () {
         $owner = User::factory()->create();
-        Group::factory()->create(['name' => 'Developers Group', 'owner_id' => $owner->id]);
-        Group::factory()->create(['name' => 'Designers Group', 'owner_id' => $owner->id]);
+        Group::factory()->create(['name' => 'Developers Group', 'owner_id' => $owner->id, 'type' => 'public']);
+        Group::factory()->create(['name' => 'Designers Group', 'owner_id' => $owner->id, 'type' => 'public']);
 
         $response = $this->getJson('/api/search/groups?query=Developers');
 
@@ -142,6 +146,7 @@ describe('Group Search', function () {
             'name' => 'Group One',
             'description' => 'This is for Laravel developers',
             'owner_id' => $owner->id,
+            'type' => 'public',
         ]);
 
         $response = $this->getJson('/api/search/groups?query=Laravel');
@@ -152,8 +157,8 @@ describe('Group Search', function () {
 
     it('can filter active groups only', function () {
         $owner = User::factory()->create();
-        Group::factory()->create(['name' => 'Active Group', 'is_active' => true, 'owner_id' => $owner->id]);
-        Group::factory()->create(['name' => 'Inactive Group', 'is_active' => false, 'owner_id' => $owner->id]);
+        Group::factory()->create(['name' => 'Active Group', 'is_active' => true, 'owner_id' => $owner->id, 'type' => 'public']);
+        Group::factory()->create(['name' => 'Inactive Group', 'is_active' => false, 'owner_id' => $owner->id, 'type' => 'public']);
 
         $response = $this->getJson('/api/search/groups?query=Group&active_only=1');
 

--- a/tests/Feature/SearchUsersTest.php
+++ b/tests/Feature/SearchUsersTest.php
@@ -29,6 +29,8 @@ beforeEach(function () {
         'password' => bcrypt('password'),
         'email_verified_at' => now(),
     ]);
+
+    $this->actingAs($this->user1, 'sanctum');
 });
 
 it('can search users by name', function () {
@@ -142,7 +144,10 @@ it('can filter users by role', function () {
     $team = Team::factory()->create(['user_id' => $this->user1->id]);
     setPermissionsTeamId($team->id);
 
-    $editor = Role::create(['name' => 'editor']);
+    // guard_name is explicit: actingAs(..., 'sanctum') in beforeEach mutates the runtime
+    // auth.defaults.guard to 'sanctum' (via Auth::shouldUse), so an implicit guard here
+    // would create a role on the wrong guard and mismatch the (web-guard) User model.
+    $editor = Role::create(['name' => 'editor', 'guard_name' => 'web']);
     $this->user1->assignRole($editor);
 
     $response = $this->getJson('/api/search/users?role=editor');

--- a/tests/Unit/SearchServiceTest.php
+++ b/tests/Unit/SearchServiceTest.php
@@ -67,12 +67,12 @@ describe('searchPosts', function () {
         expect($statuses)->not->toContain('draft');
     });
 
-    it('includes drafts when include_drafts is set', function () {
+    it('never includes drafts, even when include_drafts is set', function () {
         $user = User::factory()->create();
         Post::create(['title' => 'Draft', 'content' => 'B', 'user_id' => $user->id, 'status' => 'draft']);
 
         $result = $this->service->searchPosts(['include_drafts' => true, 'status' => 'draft']);
-        expect($result->total())->toBeGreaterThanOrEqual(1);
+        expect($result->total())->toBe(0);
     });
 
     it('filters by author id', function () {
@@ -97,13 +97,16 @@ describe('searchGroups', function () {
         expect($result->items()[0]->name)->toBe('Active Group');
     });
 
-    it('filters by type', function () {
+    it('only ever returns public groups, regardless of a type filter', function () {
         $owner = User::factory()->create();
         Group::create(['name' => 'Public', 'owner_id' => $owner->id, 'type' => 'public']);
         Group::create(['name' => 'Private', 'owner_id' => $owner->id, 'type' => 'private']);
+        Group::create(['name' => 'Restricted', 'owner_id' => $owner->id, 'type' => 'restricted']);
 
-        $result = $this->service->searchGroups(['type' => 'public']);
+        // 'type' is no longer an accepted caller filter — searchGroups always scopes to public.
+        $result = $this->service->searchGroups(['type' => 'private']);
         expect($result->total())->toBe(1);
+        expect($result->items()[0]->name)->toBe('Public');
     });
 });
 


### PR DESCRIPTION
## Summary

`/api/search/*` was unauthenticated (only `throttle:60,1`) and let anonymous
callers pull data they shouldn't see:

- `SearchService::searchPosts` skipped the `published()` scope when the
  caller passed `include_drafts=1`, exposing draft posts.
- `SearchService::searchGroups` returned groups of every `type`
  (public/private/restricted) — private and restricted groups were fully
  searchable by anyone.
- The whole endpoint required no authentication at all.

This is an OWASP broken-access-control / sensitive-data-exposure issue.

## Fix

- `routes/api.php`: search route group now requires `auth:sanctum` (kept the
  existing `throttle:60,1`).
- `SearchService::searchPosts` always applies `published()` — `include_drafts`
  no longer has any effect on the query.
- `SearchService::searchGroups` unconditionally scopes to `type('public')` —
  private/restricted groups can never be returned, and the caller-controlled
  `type` filter was removed.
- `SearchController`: dropped the now-dead `include_drafts` and `type`
  validation rules so they can't even be supplied.

## Tests

- New `tests/Feature/SearchApiSecurityTest.php`:
  - unauthenticated `users`/`posts`/`groups`/`all` search all return 401.
  - a draft post is never returned, even with `include_drafts=1&status=draft`.
  - private/restricted groups are excluded from `/api/search/groups`; a
    public group is still returned.
- Updated `SearchPostsTest`, `SearchGroupsTest`, `SearchUsersTest`,
  `SearchAllTest`, `SearchTest`, and `Unit/SearchServiceTest` to authenticate
  their requests and assert the corrected (no-leak) behavior instead of the
  old draft/private-group-exposing assertions. One test
  (`validates group search type`) was removed since the `type` param it
  validated no longer exists as a caller-controlled filter.

## Test plan
- [x] `vendor/bin/pest` — full suite green (261 passed, 12 pre-existing skips, 0 failed)
- [x] `vendor/bin/pint --test` clean on changed files
- [x] `vendor/bin/phpstan analyse` (level 9) clean on changed `app/` files