### PR TITLE
feat(security): add baseline security-headers middleware

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+    /**
+     * Attach baseline security response headers.
+     *
+     * Note: a strict Content-Security-Policy is intentionally NOT enforced here —
+     * Filament/Livewire/Vite rely on inline scripts and styles, so a real CSP needs
+     * per-app tuning (nonces). Add one deliberately when the surfaces are locked down.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $response = $next($request);
+
+        $headers = [
+            'X-Frame-Options' => 'DENY',
+            'X-Content-Type-Options' => 'nosniff',
+            'Referrer-Policy' => 'strict-origin-when-cross-origin',
+            'X-Permitted-Cross-Domain-Policies' => 'none',
+            'Permissions-Policy' => 'geolocation=(), camera=(), microphone=(), interest-cohort=()',
+        ];
+
+        // HSTS only over HTTPS, so local http development is unaffected.
+        if ($request->secure()) {
+            $headers['Strict-Transport-Security'] = 'max-age=31536000; includeSubDomains';
+        }
+
+        foreach ($headers as $name => $value) {
+            if (! $response->headers->has($name)) {
+                $response->headers->set($name, $value);
+            }
+        }
+
+        return $response;
+    }
+}

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Plugins\ModuleFilamentPlugin;
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\SetLocale;
 use App\Models\Team;
 use App\Services\ThemeManager;
@@ -59,6 +60,7 @@ class AdminPanelProvider extends PanelProvider
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
                 SetLocale::class,
+                SecurityHeaders::class,
             ])
             ->plugins([
                 // Do NOT tenant-scope Shield's RoleResource: the admin panel scopes by

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Plugins\ModuleFilamentPlugin;
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\SetLocale;
 use App\Services\ThemeManager;
 use Filament\Http\Middleware\Authenticate;
@@ -50,6 +51,7 @@ class AppPanelProvider extends PanelProvider
                 DisableBladeIconComponents::class,
                 DispatchServingFilamentEvent::class,
                 SetLocale::class,
+                SecurityHeaders::class,
             ])
             ->plugins([
                 ModuleFilamentPlugin::make()->for('App'),

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\SetLocale;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -15,7 +16,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->appendToGroup('web', [SetLocale::class]);
+        $middleware->appendToGroup('web', [SetLocale::class, SecurityHeaders::class]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->shouldRenderJsonWhen(

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,15 @@
+<?php
+
+it('adds baseline security headers to web responses', function () {
+    $response = $this->get('/');
+
+    $response->assertHeader('X-Frame-Options', 'DENY');
+    $response->assertHeader('X-Content-Type-Options', 'nosniff');
+    $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    $response->assertHeader('Permissions-Policy');
+});
+
+it('does not send HSTS over plain HTTP', function () {
+    // Local/dev http requests must not be pinned to HTTPS.
+    $this->get('/')->assertHeaderMissing('Strict-Transport-Security');
+});


### PR DESCRIPTION
## Finding (OWASP: security-headers, HIGH)

The app set **no** security response headers — no protection against clickjacking or MIME-sniffing, no transport pinning.

## Fix

New `App\Http\Middleware\SecurityHeaders` sets:
- `X-Frame-Options: DENY`
- `X-Content-Type-Options: nosniff`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `X-Permitted-Cross-Domain-Policies: none`
- `Permissions-Policy: geolocation=(), camera=(), microphone=(), interest-cohort=()`
- `Strict-Transport-Security` (max-age 1y, includeSubDomains) — **only over HTTPS**, so local http dev is unaffected.

Applied to the **web** group (`bootstrap/app.php`) and **both Filament panels** (they use their own middleware stack, so the web-group append wouldn't reach `/admin`, `/app`).

## Deliberately deferred

A strict **Content-Security-Policy** is not enforced — Filament/Livewire/Vite rely on inline scripts/styles, so a real CSP needs per-app nonce tuning. Documented in the middleware.

## Testing

TDD: `SecurityHeadersTest` asserts the headers are present on web responses and that HSTS is **absent** over plain HTTP. Full suite **258 passed / 0 failed**; Pint + PHPStan L9 clean.