### PR TITLE
feat(auth): stronger default password policy (min 12 + complexity + breach check)

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rules\Password;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Fortify;
 
@@ -34,6 +35,15 @@ class FortifyServiceProvider extends ServiceProvider
         Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
         Fortify::redirectUserForTwoFactorAuthenticationUsing(RedirectIfTwoFactorAuthenticatable::class);
+
+        // Strong default password policy for registration / reset / change.
+        // The breach check (uncompromised) only runs in production to avoid a
+        // network call — and flakiness — in tests and local dev.
+        Password::defaults(function () {
+            $rule = Password::min(12)->mixedCase()->numbers()->symbols();
+
+            return $this->app->isProduction() ? $rule->uncompromised() : $rule;
+        });
 
         RateLimiter::for('login', function (Request $request) {
             $throttleKey = Str::transliterate(Str::lower($request->string(Fortify::username())->value()).'|'.$request->ip());

--- a/tests/Feature/PasswordPolicyTest.php
+++ b/tests/Feature/PasswordPolicyTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rules\Password;
+
+function passwordFails(string $password): bool
+{
+    return Validator::make(['password' => $password], ['password' => Password::default()])->fails();
+}
+
+it('rejects short passwords (min 12)', function () {
+    expect(passwordFails('Ab1!short'))->toBeTrue(); // 8 chars
+});
+
+it('rejects passwords missing complexity', function () {
+    expect(passwordFails('alllowercaseletters'))->toBeTrue();   // no upper/number/symbol
+    expect(passwordFails('NoNumbersOrSymbols'))->toBeTrue();     // no number/symbol
+    expect(passwordFails('nosymbols1234abcd'))->toBeTrue();      // no symbol
+});
+
+it('accepts a strong password', function () {
+    expect(passwordFails('Str0ng-Passphrase!9'))->toBeFalse();
+});


### PR DESCRIPTION
## Finding (OWASP: authentication-failures, MEDIUM)

Password rules used `Password::default()` — Laravel's default is **min 8, no complexity, no breach check**, below the OWASP recommendation.

## Fix

Register `Password::defaults()` in `FortifyServiceProvider::boot()`:
- **min 12** characters
- **mixed case + numbers + symbols**
- **`->uncompromised()`** (HaveIBeenPwned breach check) — **production only**, so tests and local dev make no network call and stay deterministic.

Applies everywhere `Password::default()` is used (registration, password reset, password change) via `PasswordValidationRules`.

## Testing

TDD: `PasswordPolicyTest` — rejects short (<12) and complexity-missing passwords, accepts a strong one. Full suite **259 passed / 0 failed** (no registration flow broke — the actions use `Password::default()` which now enforces the stronger rule); Pint + PHPStan L9 clean.