### PR TITLE
Static analysis across the fleet, and the code-conformance audit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,6 +51,11 @@ jobs:
       - name: Check formatting
         run: vendor/bin/pint --test
 
+      # phpstan.neon existed and was configured at level 9 while nothing ever
+      # ran it. Scope and level are explained in that file.
+      - name: Static analysis
+        run: vendor/bin/phpstan analyse --no-progress
+
       - name: Generate application key
         run: php artisan key:generate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ composer test                  # vendor/bin/pest
 vendor/bin/pest tests/Feature/SearchTest.php
 vendor/bin/pest --filter=SearchTest
 vendor/bin/pint                # --test to check without writing
+vendor/bin/phpstan analyse     # app/ only, at the level app/ passes
 
 npm run dev                    # vite
 npm run build                  # required once, to compile the theme bundles
@@ -305,6 +306,39 @@ the moment anything reinstalled.
 
 Note that most of `tests/Unit` is integration-shaped: it boots the app, reads host config and
 asserts across several packages. Only tests needing nothing from the host belong in a package.
+
+### Static analysis
+
+**Pint and PHPStan are shipped by `liberusoftware/package-testbench`, not by any package.** It
+carries both tools as `require` and both configs — `pint.json` and `phpstan.neon` — and every
+package already dev-requires it, so no package holds a `pint.json` or `phpstan.neon` of its own. The
+reusable `package-tests.yml` invokes them with `--config vendor/liberusoftware/package-testbench/…`.
+
+`PINT.md` asks for `pint.json` at each repository root and this deliberately deviates: the same
+document treats inconsistent package configurations as a defect, and 44 committed copies is how they
+become inconsistent. Pint has **no include mechanism**, so a shared ruleset is only reachable through
+`--config`; PHPStan's `includes` would have allowed either.
+
+**The PHPStan level is a per-package ratchet**, exactly like `coverage-threshold`: a `phpstan-level`
+input in each repository's `tests.yml`, set from a measured baseline and raised only. Unset (`-1`,
+not `0` — `0` is a real level) means the package is skipped with a notice rather than failed.
+
+```bash
+scripts/measure-phpstan                          # bisect each package's ceiling → storage/app/phpstan.tsv
+scripts/set-phpstan-levels --workspace ~/code    # write it into each repo's tests.yml, raising only
+```
+
+The host analyses **`app/` only**, at the level `app/` passes. `modules/` and `themes/` are Composer
+output, so analysing them here would use the host's resolution rather than the package's own — and a
+package is only honest when analysed against the tree a consumer installs.
+
+`phpstan.neon` carries an explicit `--memory-limit` in CI: PHPStan exhausts a 128M `php.ini` default
+and reports it as `Child process error (exit code 255) while running parallel worker`, which reads
+like a tool bug rather than a limit.
+
+**Where the fleet stands against the code-level standards is `docs/CODE-CONFORMANCE.md`** — 37
+findings over 122 audited rule clusters, ranked by consequence. It fixes nothing; each finding is a
+separate decision.
 
 ## Known upgrade blockers
 

--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
-            "version": "1.3.10",
+            "version": "1.3.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/AnourValar/eloquent-serialize.git",
-                "reference": "2be26f176b764a2d6f20118bfa4b125f71fa88f8"
+                "reference": "abd890c4d1ad8e90dd454d01283fbf342f80f1e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/AnourValar/eloquent-serialize/zipball/2be26f176b764a2d6f20118bfa4b125f71fa88f8",
-                "reference": "2be26f176b764a2d6f20118bfa4b125f71fa88f8",
+                "url": "https://api.github.com/repos/AnourValar/eloquent-serialize/zipball/abd890c4d1ad8e90dd454d01283fbf342f80f1e5",
+                "reference": "abd890c4d1ad8e90dd454d01283fbf342f80f1e5",
                 "shasum": ""
             },
             "require": {
@@ -67,9 +67,9 @@
             ],
             "support": {
                 "issues": "https://github.com/AnourValar/eloquent-serialize/issues",
-                "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.3.10"
+                "source": "https://github.com/AnourValar/eloquent-serialize/tree/1.3.11"
             },
-            "time": "2026-06-20T14:30:25+00:00"
+            "time": "2026-08-07T06:14:19+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
@@ -5075,16 +5075,16 @@
         },
         {
             "name": "liberusoftware/activity-comments",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-activity-comments.git",
-                "reference": "4f09359a1cef03905fa71a651325f51ee8cbc484"
+                "reference": "416a1fdfb51bf5dbe331326709b44fdd7b9d3f32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-activity-comments/zipball/4f09359a1cef03905fa71a651325f51ee8cbc484",
-                "reference": "4f09359a1cef03905fa71a651325f51ee8cbc484",
+                "url": "https://api.github.com/repos/liberusoftware/module-activity-comments/zipball/416a1fdfb51bf5dbe331326709b44fdd7b9d3f32",
+                "reference": "416a1fdfb51bf5dbe331326709b44fdd7b9d3f32",
                 "shasum": ""
             },
             "require": {
@@ -5123,10 +5123,10 @@
             ],
             "description": "Generic authorized timelines, comments, mentions, subscriptions, attachments, and visibility.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-activity-comments/tree/1.4.1",
+                "source": "https://github.com/liberusoftware/module-activity-comments/tree/1.4.2",
                 "issues": "https://github.com/liberusoftware/module-activity-comments/issues"
             },
-            "time": "2026-08-07T10:12:49+00:00"
+            "time": "2026-08-07T14:25:02+00:00"
         },
         {
             "name": "liberusoftware/analytics-contracts",
@@ -5163,16 +5163,16 @@
         },
         {
             "name": "liberusoftware/analytics-core",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-analytics-core.git",
-                "reference": "78a687b31c78c1a536dc1f8f898a1c41197b1dcf"
+                "reference": "b302f2e18910c3589fc3497a241bd56db809da93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-core/zipball/78a687b31c78c1a536dc1f8f898a1c41197b1dcf",
-                "reference": "78a687b31c78c1a536dc1f8f898a1c41197b1dcf",
+                "url": "https://api.github.com/repos/liberusoftware/module-analytics-core/zipball/b302f2e18910c3589fc3497a241bd56db809da93",
+                "reference": "b302f2e18910c3589fc3497a241bd56db809da93",
                 "shasum": ""
             },
             "require": {
@@ -5212,23 +5212,23 @@
             ],
             "description": "Consent-aware provider-neutral analytics event routing and durable delivery evidence.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-analytics-core/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-analytics-core/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-analytics-core/issues"
             },
-            "time": "2026-08-07T09:00:10+00:00"
+            "time": "2026-08-07T14:25:08+00:00"
         },
         {
             "name": "liberusoftware/analytics-google",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-analytics-google.git",
-                "reference": "74270131ee42853e8f30113c6a291b4d37e81d37"
+                "reference": "60d4b39b689e13557829dd5b1fbb62ebb1d589c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-google/zipball/74270131ee42853e8f30113c6a291b4d37e81d37",
-                "reference": "74270131ee42853e8f30113c6a291b4d37e81d37",
+                "url": "https://api.github.com/repos/liberusoftware/module-analytics-google/zipball/60d4b39b689e13557829dd5b1fbb62ebb1d589c6",
+                "reference": "60d4b39b689e13557829dd5b1fbb62ebb1d589c6",
                 "shasum": ""
             },
             "require": {
@@ -5267,23 +5267,23 @@
             ],
             "description": "Consent-aware Google Analytics event mapping adapter.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-analytics-google/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-analytics-google/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-analytics-google/issues"
             },
-            "time": "2026-08-07T09:00:10+00:00"
+            "time": "2026-08-07T14:25:08+00:00"
         },
         {
             "name": "liberusoftware/analytics-meta",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-analytics-meta.git",
-                "reference": "d3dc0c9b852a3b222f773c84e2a1c1680060133e"
+                "reference": "e087a4499ec299462ebdacd574ee12e52d36cc4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-analytics-meta/zipball/d3dc0c9b852a3b222f773c84e2a1c1680060133e",
-                "reference": "d3dc0c9b852a3b222f773c84e2a1c1680060133e",
+                "url": "https://api.github.com/repos/liberusoftware/module-analytics-meta/zipball/e087a4499ec299462ebdacd574ee12e52d36cc4c",
+                "reference": "e087a4499ec299462ebdacd574ee12e52d36cc4c",
                 "shasum": ""
             },
             "require": {
@@ -5322,23 +5322,23 @@
             ],
             "description": "Consent-aware Meta server-side event mapping and normalized customer-data adapter.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-analytics-meta/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-analytics-meta/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-analytics-meta/issues"
             },
-            "time": "2026-08-07T09:00:10+00:00"
+            "time": "2026-08-07T14:25:08+00:00"
         },
         {
             "name": "liberusoftware/api-access",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-api-access.git",
-                "reference": "72eee42bcf29f88c7c40d664ee9fd74200dd6fa5"
+                "reference": "5c79a794e1e64e84efde7305bde23a1dca459168"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-api-access/zipball/72eee42bcf29f88c7c40d664ee9fd74200dd6fa5",
-                "reference": "72eee42bcf29f88c7c40d664ee9fd74200dd6fa5",
+                "url": "https://api.github.com/repos/liberusoftware/module-api-access/zipball/5c79a794e1e64e84efde7305bde23a1dca459168",
+                "reference": "5c79a794e1e64e84efde7305bde23a1dca459168",
                 "shasum": ""
             },
             "require": {
@@ -5378,23 +5378,23 @@
             ],
             "description": "API token, scope, version, rate-limit, idempotency, and revocation policy.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-api-access/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-api-access/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-api-access/issues"
             },
-            "time": "2026-08-07T09:00:10+00:00"
+            "time": "2026-08-07T14:25:08+00:00"
         },
         {
             "name": "liberusoftware/application",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-application.git",
-                "reference": "ab431a7f0e48defd7408d7ff4f62efdde77601c9"
+                "reference": "f4fe1f694a693308398e50c3894ca266bece75ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-application/zipball/ab431a7f0e48defd7408d7ff4f62efdde77601c9",
-                "reference": "ab431a7f0e48defd7408d7ff4f62efdde77601c9",
+                "url": "https://api.github.com/repos/liberusoftware/module-application/zipball/f4fe1f694a693308398e50c3894ca266bece75ac",
+                "reference": "f4fe1f694a693308398e50c3894ca266bece75ac",
                 "shasum": ""
             },
             "require": {
@@ -5433,23 +5433,23 @@
             ],
             "description": "Required application metadata, health, clocks, identifiers, and secure HTTP defaults.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-application/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-application/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-application/issues"
             },
-            "time": "2026-08-07T09:00:10+00:00"
+            "time": "2026-08-07T14:25:08+00:00"
         },
         {
             "name": "liberusoftware/audit",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-audit.git",
-                "reference": "765fa686c604570ccf41f2f6db2ba8d7e859aaa8"
+                "reference": "78c4f3b0f59484fd928cff4cc1c63a0e32f75857"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-audit/zipball/765fa686c604570ccf41f2f6db2ba8d7e859aaa8",
-                "reference": "765fa686c604570ccf41f2f6db2ba8d7e859aaa8",
+                "url": "https://api.github.com/repos/liberusoftware/module-audit/zipball/78c4f3b0f59484fd928cff4cc1c63a0e32f75857",
+                "reference": "78c4f3b0f59484fd928cff4cc1c63a0e32f75857",
                 "shasum": ""
             },
             "require": {
@@ -5488,10 +5488,10 @@
             ],
             "description": "Contextual material-change audit records with correlation and retention boundaries.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-audit/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-audit/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-audit/issues"
             },
-            "time": "2026-08-07T09:00:14+00:00"
+            "time": "2026-08-07T14:25:10+00:00"
         },
         {
             "name": "liberusoftware/composer-installer",
@@ -5543,16 +5543,16 @@
         },
         {
             "name": "liberusoftware/currency-context",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-currency-context.git",
-                "reference": "b7da5a624fba8af9cf535d2f4b8ad88374b5cfa3"
+                "reference": "10f4df26157d7c5fee683d75f0a542c689afdd57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-currency-context/zipball/b7da5a624fba8af9cf535d2f4b8ad88374b5cfa3",
-                "reference": "b7da5a624fba8af9cf535d2f4b8ad88374b5cfa3",
+                "url": "https://api.github.com/repos/liberusoftware/module-currency-context/zipball/10f4df26157d7c5fee683d75f0a542c689afdd57",
+                "reference": "10f4df26157d7c5fee683d75f0a542c689afdd57",
                 "shasum": ""
             },
             "require": {
@@ -5591,23 +5591,23 @@
             ],
             "description": "Precise money values, ISO currency metadata, context, formatting, and exchange-rate contracts.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-currency-context/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-currency-context/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-currency-context/issues"
             },
-            "time": "2026-08-07T09:00:16+00:00"
+            "time": "2026-08-07T14:25:15+00:00"
         },
         {
             "name": "liberusoftware/developer-experience",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-developer-experience.git",
-                "reference": "7d93b53cf57ca418290e3066853baff48e60c28b"
+                "reference": "2a2f574430611175af6ff430d65156a56be7b657"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-developer-experience/zipball/7d93b53cf57ca418290e3066853baff48e60c28b",
-                "reference": "7d93b53cf57ca418290e3066853baff48e60c28b",
+                "url": "https://api.github.com/repos/liberusoftware/module-developer-experience/zipball/2a2f574430611175af6ff430d65156a56be7b657",
+                "reference": "2a2f574430611175af6ff430d65156a56be7b657",
                 "shasum": ""
             },
             "require": {
@@ -5646,23 +5646,23 @@
             ],
             "description": "Foundation diagnostics and reproducible development/quality conventions.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-developer-experience/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-developer-experience/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-developer-experience/issues"
             },
-            "time": "2026-08-07T09:00:17+00:00"
+            "time": "2026-08-07T14:25:15+00:00"
         },
         {
             "name": "liberusoftware/feature-flags",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-feature-flags.git",
-                "reference": "3bde95ff3da7167446c19abaaba644dd33d2a8d9"
+                "reference": "f0701fbb929b8d5f330204b3b53c1901cec0749e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-feature-flags/zipball/3bde95ff3da7167446c19abaaba644dd33d2a8d9",
-                "reference": "3bde95ff3da7167446c19abaaba644dd33d2a8d9",
+                "url": "https://api.github.com/repos/liberusoftware/module-feature-flags/zipball/f0701fbb929b8d5f330204b3b53c1901cec0749e",
+                "reference": "f0701fbb929b8d5f330204b3b53c1901cec0749e",
                 "shasum": ""
             },
             "require": {
@@ -5701,23 +5701,23 @@
             ],
             "description": "Typed rollout flags with stable environment, tenant, and actor targeting.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-feature-flags/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-feature-flags/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-feature-flags/issues"
             },
-            "time": "2026-08-07T09:00:21+00:00"
+            "time": "2026-08-07T14:25:15+00:00"
         },
         {
             "name": "liberusoftware/files-media",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-files-media.git",
-                "reference": "b0ff64b27b5c053349950eb92d7c013043622f98"
+                "reference": "214f00cd168620fe6fa209c6669a206534129ff5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-files-media/zipball/b0ff64b27b5c053349950eb92d7c013043622f98",
-                "reference": "b0ff64b27b5c053349950eb92d7c013043622f98",
+                "url": "https://api.github.com/repos/liberusoftware/module-files-media/zipball/214f00cd168620fe6fa209c6669a206534129ff5",
+                "reference": "214f00cd168620fe6fa209c6669a206534129ff5",
                 "shasum": ""
             },
             "require": {
@@ -5756,23 +5756,23 @@
             ],
             "description": "Secure upload policy, malware-scanner contract, media metadata, access, and retention foundations.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-files-media/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-files-media/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-files-media/issues"
             },
-            "time": "2026-08-07T09:00:22+00:00"
+            "time": "2026-08-07T14:25:15+00:00"
         },
         {
             "name": "liberusoftware/identity-core",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-identity-core.git",
-                "reference": "56dee1992502c208b0fc00afd2ec18c5e662060a"
+                "reference": "46d9b48899910a511285761f990a1d7f96531189"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-identity-core/zipball/56dee1992502c208b0fc00afd2ec18c5e662060a",
-                "reference": "56dee1992502c208b0fc00afd2ec18c5e662060a",
+                "url": "https://api.github.com/repos/liberusoftware/module-identity-core/zipball/46d9b48899910a511285761f990a1d7f96531189",
+                "reference": "46d9b48899910a511285761f990a1d7f96531189",
                 "shasum": ""
             },
             "require": {
@@ -5810,23 +5810,23 @@
             ],
             "description": "Provider-neutral identity policy, normalization, and versioned security events.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-identity-core/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-identity-core/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-identity-core/issues"
             },
-            "time": "2026-08-07T09:00:23+00:00"
+            "time": "2026-08-07T14:25:16+00:00"
         },
         {
             "name": "liberusoftware/identity-core-filament",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-identity-core-filament.git",
-                "reference": "cb6d81bf762eb4c154c557d661d661b8869a711f"
+                "reference": "34519fdd11c96b7db55def83ef50321265b81ba8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-identity-core-filament/zipball/cb6d81bf762eb4c154c557d661d661b8869a711f",
-                "reference": "cb6d81bf762eb4c154c557d661d661b8869a711f",
+                "url": "https://api.github.com/repos/liberusoftware/module-identity-core-filament/zipball/34519fdd11c96b7db55def83ef50321265b81ba8",
+                "reference": "34519fdd11c96b7db55def83ef50321265b81ba8",
                 "shasum": ""
             },
             "require": {
@@ -5864,23 +5864,23 @@
             ],
             "description": "Filament administration adapter for the configured Liberu identity model.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-identity-core-filament/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-identity-core-filament/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-identity-core-filament/issues"
             },
-            "time": "2026-08-07T10:01:17+00:00"
+            "time": "2026-08-07T14:25:21+00:00"
         },
         {
             "name": "liberusoftware/identity-socialstream",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-identity-socialstream.git",
-                "reference": "f9bc0a3f72347058ac72b698de6b4b75569541e8"
+                "reference": "faea00423bd97e3de696e37cb5d7cc6bafc0edf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-identity-socialstream/zipball/f9bc0a3f72347058ac72b698de6b4b75569541e8",
-                "reference": "f9bc0a3f72347058ac72b698de6b4b75569541e8",
+                "url": "https://api.github.com/repos/liberusoftware/module-identity-socialstream/zipball/faea00423bd97e3de696e37cb5d7cc6bafc0edf2",
+                "reference": "faea00423bd97e3de696e37cb5d7cc6bafc0edf2",
                 "shasum": ""
             },
             "require": {
@@ -5922,23 +5922,23 @@
             ],
             "description": "Socialstream/Socialite identity-linking provider adapter.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-identity-socialstream/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-identity-socialstream/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-identity-socialstream/issues"
             },
-            "time": "2026-08-07T09:00:23+00:00"
+            "time": "2026-08-07T14:25:24+00:00"
         },
         {
             "name": "liberusoftware/import-export",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-import-export.git",
-                "reference": "7682b473033b7ab820c544f7ebc8fa0dc494e400"
+                "reference": "075032d5033056c3b4a10a010673de3d4a57159c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-import-export/zipball/7682b473033b7ab820c544f7ebc8fa0dc494e400",
-                "reference": "7682b473033b7ab820c544f7ebc8fa0dc494e400",
+                "url": "https://api.github.com/repos/liberusoftware/module-import-export/zipball/075032d5033056c3b4a10a010673de3d4a57159c",
+                "reference": "075032d5033056c3b4a10a010673de3d4a57159c",
                 "shasum": ""
             },
             "require": {
@@ -5977,23 +5977,23 @@
             ],
             "description": "Versioned transfer schemas, mapping, dry runs, validation, queued progress, reports, and retention.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-import-export/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-import-export/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-import-export/issues"
             },
-            "time": "2026-08-07T09:00:25+00:00"
+            "time": "2026-08-07T14:25:23+00:00"
         },
         {
             "name": "liberusoftware/integrations",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-integrations.git",
-                "reference": "68bafe964b252e53947181b56b23e0a7e8f9986d"
+                "reference": "9569c7b2e48633fc47131a0a3533dfb7a4d516fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-integrations/zipball/68bafe964b252e53947181b56b23e0a7e8f9986d",
-                "reference": "68bafe964b252e53947181b56b23e0a7e8f9986d",
+                "url": "https://api.github.com/repos/liberusoftware/module-integrations/zipball/9569c7b2e48633fc47131a0a3533dfb7a4d516fc",
+                "reference": "9569c7b2e48633fc47131a0a3533dfb7a4d516fc",
                 "shasum": ""
             },
             "require": {
@@ -6032,23 +6032,23 @@
             ],
             "description": "Provider adapter registry and protected connection lifecycle.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-integrations/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-integrations/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-integrations/issues"
             },
-            "time": "2026-08-07T09:00:24+00:00"
+            "time": "2026-08-07T14:25:23+00:00"
         },
         {
             "name": "liberusoftware/jetstream-bridge",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-jetstream-bridge.git",
-                "reference": "7d65981b2e5e9aa3ff4a6c8de4bdc5278e81d8ac"
+                "reference": "7ba43cc22d76d231d74b3987bbb7d40dd2a0f445"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-jetstream-bridge/zipball/7d65981b2e5e9aa3ff4a6c8de4bdc5278e81d8ac",
-                "reference": "7d65981b2e5e9aa3ff4a6c8de4bdc5278e81d8ac",
+                "url": "https://api.github.com/repos/liberusoftware/module-jetstream-bridge/zipball/7ba43cc22d76d231d74b3987bbb7d40dd2a0f445",
+                "reference": "7ba43cc22d76d231d74b3987bbb7d40dd2a0f445",
                 "shasum": ""
             },
             "require": {
@@ -6089,10 +6089,10 @@
             ],
             "description": "Fortify and Jetstream-compatible action adapters for Liberu identity capabilities.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-jetstream-bridge/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-jetstream-bridge/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-jetstream-bridge/issues"
             },
-            "time": "2026-08-07T09:00:28+00:00"
+            "time": "2026-08-07T14:25:24+00:00"
         },
         {
             "name": "liberusoftware/localization-contracts",
@@ -6129,16 +6129,16 @@
         },
         {
             "name": "liberusoftware/localization-core",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-localization-core.git",
-                "reference": "88aa318e59b8f9ac5a178380513a03282552622c"
+                "reference": "c77a5aed99bd101eeff7a7a94dde0a969a0f38ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-localization-core/zipball/88aa318e59b8f9ac5a178380513a03282552622c",
-                "reference": "88aa318e59b8f9ac5a178380513a03282552622c",
+                "url": "https://api.github.com/repos/liberusoftware/module-localization-core/zipball/c77a5aed99bd101eeff7a7a94dde0a969a0f38ab",
+                "reference": "c77a5aed99bd101eeff7a7a94dde0a969a0f38ab",
                 "shasum": ""
             },
             "require": {
@@ -6180,23 +6180,23 @@
             ],
             "description": "Locale resolution, preferences, propagation, and UI direction for Liberu applications.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-localization-core/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-localization-core/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-localization-core/issues"
             },
-            "time": "2026-08-07T09:00:29+00:00"
+            "time": "2026-08-07T14:25:23+00:00"
         },
         {
             "name": "liberusoftware/localization-core-livewire",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-localization-core-livewire.git",
-                "reference": "34b83e1b745d2be614fd5afc65109a32dbb6e262"
+                "reference": "31553cab97641e83fc702974c3159de78afdcec7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-localization-core-livewire/zipball/34b83e1b745d2be614fd5afc65109a32dbb6e262",
-                "reference": "34b83e1b745d2be614fd5afc65109a32dbb6e262",
+                "url": "https://api.github.com/repos/liberusoftware/module-localization-core-livewire/zipball/31553cab97641e83fc702974c3159de78afdcec7",
+                "reference": "31553cab97641e83fc702974c3159de78afdcec7",
                 "shasum": ""
             },
             "require": {
@@ -6235,23 +6235,23 @@
             ],
             "description": "Livewire locale-switching presentation adapter for Liberu Localization.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-localization-core-livewire/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-localization-core-livewire/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-localization-core-livewire/issues"
             },
-            "time": "2026-08-07T09:00:30+00:00"
+            "time": "2026-08-07T14:25:29+00:00"
         },
         {
             "name": "liberusoftware/localization-mymemory",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-localization-mymemory.git",
-                "reference": "34519878906e2742f945e0e2a69fa885b7ff4ef3"
+                "reference": "bf11fef28492b3a311cb252f484205b5875c5d9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-localization-mymemory/zipball/34519878906e2742f945e0e2a69fa885b7ff4ef3",
-                "reference": "34519878906e2742f945e0e2a69fa885b7ff4ef3",
+                "url": "https://api.github.com/repos/liberusoftware/module-localization-mymemory/zipball/bf11fef28492b3a311cb252f484205b5875c5d9e",
+                "reference": "bf11fef28492b3a311cb252f484205b5875c5d9e",
                 "shasum": ""
             },
             "require": {
@@ -6291,23 +6291,23 @@
             ],
             "description": "MyMemory machine-translation adapter for Liberu Localization.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-localization-mymemory/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-localization-mymemory/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-localization-mymemory/issues"
             },
-            "time": "2026-08-07T09:00:31+00:00"
+            "time": "2026-08-07T14:25:31+00:00"
         },
         {
             "name": "liberusoftware/module-manager",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-module-manager.git",
-                "reference": "429c41b05e15945cc4143355d15aa8f1a80f3712"
+                "reference": "688fc9c01008bfd5258afa2a78587c48804ec2e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-module-manager/zipball/429c41b05e15945cc4143355d15aa8f1a80f3712",
-                "reference": "429c41b05e15945cc4143355d15aa8f1a80f3712",
+                "url": "https://api.github.com/repos/liberusoftware/module-module-manager/zipball/688fc9c01008bfd5258afa2a78587c48804ec2e7",
+                "reference": "688fc9c01008bfd5258afa2a78587c48804ec2e7",
                 "shasum": ""
             },
             "require": {
@@ -6346,23 +6346,23 @@
             ],
             "description": "Deterministic manifest discovery and runtime enablement for Liberu modules.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-module-manager/tree/1.4.1",
+                "source": "https://github.com/liberusoftware/module-module-manager/tree/1.4.2",
                 "issues": "https://github.com/liberusoftware/module-module-manager/issues"
             },
-            "time": "2026-08-07T10:12:49+00:00"
+            "time": "2026-08-07T14:25:25+00:00"
         },
         {
             "name": "liberusoftware/module-manager-filament",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-module-manager-filament.git",
-                "reference": "39876d68722226e9dbe658d29b29a2fd559801c2"
+                "reference": "44378fb5b6b5ea3239639f09ad51b1a8b8696026"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-module-manager-filament/zipball/39876d68722226e9dbe658d29b29a2fd559801c2",
-                "reference": "39876d68722226e9dbe658d29b29a2fd559801c2",
+                "url": "https://api.github.com/repos/liberusoftware/module-module-manager-filament/zipball/44378fb5b6b5ea3239639f09ad51b1a8b8696026",
+                "reference": "44378fb5b6b5ea3239639f09ad51b1a8b8696026",
                 "shasum": ""
             },
             "require": {
@@ -6401,23 +6401,23 @@
             ],
             "description": "Filament operations presentation adapter for the Liberu Module Manager.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-module-manager-filament/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-module-manager-filament/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-module-manager-filament/issues"
             },
-            "time": "2026-08-07T09:00:36+00:00"
+            "time": "2026-08-07T14:25:35+00:00"
         },
         {
             "name": "liberusoftware/notifications",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-notifications.git",
-                "reference": "5c1761febe954cc14b8d1c54c95a5d94aae3077c"
+                "reference": "c218aa80a8773b7feadd0a884172a88135446ef9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-notifications/zipball/5c1761febe954cc14b8d1c54c95a5d94aae3077c",
-                "reference": "5c1761febe954cc14b8d1c54c95a5d94aae3077c",
+                "url": "https://api.github.com/repos/liberusoftware/module-notifications/zipball/c218aa80a8773b7feadd0a884172a88135446ef9",
+                "reference": "c218aa80a8773b7feadd0a884172a88135446ef9",
                 "shasum": ""
             },
             "require": {
@@ -6456,23 +6456,23 @@
             ],
             "description": "Localized notification preferences, channel policy, inbox delivery state, and quiet hours.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-notifications/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-notifications/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-notifications/issues"
             },
-            "time": "2026-08-07T09:00:34+00:00"
+            "time": "2026-08-07T14:25:32+00:00"
         },
         {
             "name": "liberusoftware/observability",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-observability.git",
-                "reference": "1cb112f13f933880b3db29f86c6a5db24de4d6cd"
+                "reference": "6adfdab5abf83d6f39473345822fda97f3f05ecb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-observability/zipball/1cb112f13f933880b3db29f86c6a5db24de4d6cd",
-                "reference": "1cb112f13f933880b3db29f86c6a5db24de4d6cd",
+                "url": "https://api.github.com/repos/liberusoftware/module-observability/zipball/6adfdab5abf83d6f39473345822fda97f3f05ecb",
+                "reference": "6adfdab5abf83d6f39473345822fda97f3f05ecb",
                 "shasum": ""
             },
             "require": {
@@ -6512,23 +6512,23 @@
             ],
             "description": "Structured diagnostics, monitoring dashboards, health signals, and redaction defaults.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-observability/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-observability/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-observability/issues"
             },
-            "time": "2026-08-07T09:00:36+00:00"
+            "time": "2026-08-07T14:25:32+00:00"
         },
         {
             "name": "liberusoftware/organizations-teams",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-organizations-teams.git",
-                "reference": "7a06f84086ce2eece1eb1d6be7baa8b3fd5b36c1"
+                "reference": "2193133f012266bfd76c696609785dc08f78c850"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-organizations-teams/zipball/7a06f84086ce2eece1eb1d6be7baa8b3fd5b36c1",
-                "reference": "7a06f84086ce2eece1eb1d6be7baa8b3fd5b36c1",
+                "url": "https://api.github.com/repos/liberusoftware/module-organizations-teams/zipball/2193133f012266bfd76c696609785dc08f78c850",
+                "reference": "2193133f012266bfd76c696609785dc08f78c850",
                 "shasum": ""
             },
             "require": {
@@ -6568,23 +6568,23 @@
             ],
             "description": "Organization, team, membership, invitation, ownership, and context foundation.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-organizations-teams/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-organizations-teams/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-organizations-teams/issues"
             },
-            "time": "2026-08-07T09:00:37+00:00"
+            "time": "2026-08-07T14:25:34+00:00"
         },
         {
             "name": "liberusoftware/organizations-teams-filament",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-organizations-teams-filament.git",
-                "reference": "185d71ef79f6b45f108e80d731866d9b189fbce1"
+                "reference": "ce57c44ef89eb852c9c1737d65de7a9e5ffa4b76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-organizations-teams-filament/zipball/185d71ef79f6b45f108e80d731866d9b189fbce1",
-                "reference": "185d71ef79f6b45f108e80d731866d9b189fbce1",
+                "url": "https://api.github.com/repos/liberusoftware/module-organizations-teams-filament/zipball/ce57c44ef89eb852c9c1737d65de7a9e5ffa4b76",
+                "reference": "ce57c44ef89eb852c9c1737d65de7a9e5ffa4b76",
                 "shasum": ""
             },
             "require": {
@@ -6622,23 +6622,23 @@
             ],
             "description": "Filament administration adapter for organizations and teams.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-organizations-teams-filament/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-organizations-teams-filament/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-organizations-teams-filament/issues"
             },
-            "time": "2026-08-07T10:01:17+00:00"
+            "time": "2026-08-07T14:25:42+00:00"
         },
         {
             "name": "liberusoftware/profiles",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-profiles.git",
-                "reference": "acf2c8ab114ff452ef331b56d41c1e0e39d9f819"
+                "reference": "bdf7c4cb01bf602735df5ecf01d02cbb88b659fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-profiles/zipball/acf2c8ab114ff452ef331b56d41c1e0e39d9f819",
-                "reference": "acf2c8ab114ff452ef331b56d41c1e0e39d9f819",
+                "url": "https://api.github.com/repos/liberusoftware/module-profiles/zipball/bdf7c4cb01bf602735df5ecf01d02cbb88b659fe",
+                "reference": "bdf7c4cb01bf602735df5ecf01d02cbb88b659fe",
                 "shasum": ""
             },
             "require": {
@@ -6677,23 +6677,23 @@
             ],
             "description": "Controlled profile updates and user presentation preferences.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-profiles/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-profiles/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-profiles/issues"
             },
-            "time": "2026-08-07T09:00:38+00:00"
+            "time": "2026-08-07T14:25:39+00:00"
         },
         {
             "name": "liberusoftware/roles-permissions",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-roles-permissions.git",
-                "reference": "7b3ecbe0190aaccf7b92a0ff7c50c281fb041ef9"
+                "reference": "d061b98bbe185ae966e8fe6ea4761bddf48aed9d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-roles-permissions/zipball/7b3ecbe0190aaccf7b92a0ff7c50c281fb041ef9",
-                "reference": "7b3ecbe0190aaccf7b92a0ff7c50c281fb041ef9",
+                "url": "https://api.github.com/repos/liberusoftware/module-roles-permissions/zipball/d061b98bbe185ae966e8fe6ea4761bddf48aed9d",
+                "reference": "d061b98bbe185ae966e8fe6ea4761bddf48aed9d",
                 "shasum": ""
             },
             "require": {
@@ -6732,23 +6732,23 @@
             ],
             "description": "Contextual roles, permissions, policies, and authorization safeguards.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-roles-permissions/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-roles-permissions/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-roles-permissions/issues"
             },
-            "time": "2026-08-07T09:00:38+00:00"
+            "time": "2026-08-07T14:25:40+00:00"
         },
         {
             "name": "liberusoftware/roles-permissions-filament",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-roles-permissions-filament.git",
-                "reference": "5118ca39c415074a9a93a7fbb521fbbe433a835c"
+                "reference": "788117df5f64d16103ce595a42fc3506d97a16d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-roles-permissions-filament/zipball/5118ca39c415074a9a93a7fbb521fbbe433a835c",
-                "reference": "5118ca39c415074a9a93a7fbb521fbbe433a835c",
+                "url": "https://api.github.com/repos/liberusoftware/module-roles-permissions-filament/zipball/788117df5f64d16103ce595a42fc3506d97a16d2",
+                "reference": "788117df5f64d16103ce595a42fc3506d97a16d2",
                 "shasum": ""
             },
             "require": {
@@ -6787,23 +6787,23 @@
             ],
             "description": "Filament Shield presentation adapter for Liberu authorization.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-roles-permissions-filament/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-roles-permissions-filament/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-roles-permissions-filament/issues"
             },
-            "time": "2026-08-07T10:01:17+00:00"
+            "time": "2026-08-07T14:25:45+00:00"
         },
         {
             "name": "liberusoftware/scheduler-queues",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-scheduler-queues.git",
-                "reference": "a1f3820331e297727bbf5819a876176aefcd9c9c"
+                "reference": "fdfb3b1b3d8b9c3142fa670063da5ae116fa5c76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-scheduler-queues/zipball/a1f3820331e297727bbf5819a876176aefcd9c9c",
-                "reference": "a1f3820331e297727bbf5819a876176aefcd9c9c",
+                "url": "https://api.github.com/repos/liberusoftware/module-scheduler-queues/zipball/fdfb3b1b3d8b9c3142fa670063da5ae116fa5c76",
+                "reference": "fdfb3b1b3d8b9c3142fa670063da5ae116fa5c76",
                 "shasum": ""
             },
             "require": {
@@ -6842,23 +6842,23 @@
             ],
             "description": "Queue idempotency, retry, failure, scheduling, locking, and deployment conventions.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-scheduler-queues/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-scheduler-queues/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-scheduler-queues/issues"
             },
-            "time": "2026-08-07T09:00:41+00:00"
+            "time": "2026-08-07T14:25:42+00:00"
         },
         {
             "name": "liberusoftware/search",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-search.git",
-                "reference": "d4231b8563cb557b84f3eb2327e600a58a673d7a"
+                "reference": "d2617f80de4c267adf4593b357b545c9ec762188"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-search/zipball/d4231b8563cb557b84f3eb2327e600a58a673d7a",
-                "reference": "d4231b8563cb557b84f3eb2327e600a58a673d7a",
+                "url": "https://api.github.com/repos/liberusoftware/module-search/zipball/d2617f80de4c267adf4593b357b545c9ec762188",
+                "reference": "d2617f80de4c267adf4593b357b545c9ec762188",
                 "shasum": ""
             },
             "require": {
@@ -6898,23 +6898,23 @@
             ],
             "description": "Provider-neutral authorized search contracts and local Eloquent driver.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-search/tree/1.5.0",
+                "source": "https://github.com/liberusoftware/module-search/tree/1.5.1",
                 "issues": "https://github.com/liberusoftware/module-search/issues"
             },
-            "time": "2026-08-07T10:12:13+00:00"
+            "time": "2026-08-07T14:25:44+00:00"
         },
         {
             "name": "liberusoftware/search-api",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-search-api.git",
-                "reference": "ae26c9b93c9e555a8950bab1460538ee9e576a35"
+                "reference": "73a5e71c61c7199896ea9a8d01012fa832140f5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-search-api/zipball/ae26c9b93c9e555a8950bab1460538ee9e576a35",
-                "reference": "ae26c9b93c9e555a8950bab1460538ee9e576a35",
+                "url": "https://api.github.com/repos/liberusoftware/module-search-api/zipball/73a5e71c61c7199896ea9a8d01012fa832140f5d",
+                "reference": "73a5e71c61c7199896ea9a8d01012fa832140f5d",
                 "shasum": ""
             },
             "require": {
@@ -6953,23 +6953,23 @@
             ],
             "description": "HTTP API presentation adapter for Liberu Search.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-search-api/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-search-api/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-search-api/issues"
             },
-            "time": "2026-08-07T09:00:42+00:00"
+            "time": "2026-08-07T14:25:47+00:00"
         },
         {
             "name": "liberusoftware/sessions-devices",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-sessions-devices.git",
-                "reference": "1116cb56e4626a6b4a65c8348abec3d0c95f247b"
+                "reference": "164817b59449f6930af4ff08d93c21b93368c738"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-sessions-devices/zipball/1116cb56e4626a6b4a65c8348abec3d0c95f247b",
-                "reference": "1116cb56e4626a6b4a65c8348abec3d0c95f247b",
+                "url": "https://api.github.com/repos/liberusoftware/module-sessions-devices/zipball/164817b59449f6930af4ff08d93c21b93368c738",
+                "reference": "164817b59449f6930af4ff08d93c21b93368c738",
                 "shasum": ""
             },
             "require": {
@@ -7008,23 +7008,23 @@
             ],
             "description": "Privacy-conscious session inventory and revocation.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-sessions-devices/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-sessions-devices/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-sessions-devices/issues"
             },
-            "time": "2026-08-07T09:00:43+00:00"
+            "time": "2026-08-07T14:25:49+00:00"
         },
         {
             "name": "liberusoftware/sessions-devices-filament",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-sessions-devices-filament.git",
-                "reference": "202c43274418b3db94d6b0d67bee31488d598ad0"
+                "reference": "91eb6d30430ad82b21dc57c68ffbaa804299d41f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-sessions-devices-filament/zipball/202c43274418b3db94d6b0d67bee31488d598ad0",
-                "reference": "202c43274418b3db94d6b0d67bee31488d598ad0",
+                "url": "https://api.github.com/repos/liberusoftware/module-sessions-devices-filament/zipball/91eb6d30430ad82b21dc57c68ffbaa804299d41f",
+                "reference": "91eb6d30430ad82b21dc57c68ffbaa804299d41f",
                 "shasum": ""
             },
             "require": {
@@ -7062,23 +7062,23 @@
             ],
             "description": "Filament account-security presentation adapter for Liberu Sessions and Devices.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-sessions-devices-filament/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-sessions-devices-filament/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-sessions-devices-filament/issues"
             },
-            "time": "2026-08-07T09:00:46+00:00"
+            "time": "2026-08-07T14:25:53+00:00"
         },
         {
             "name": "liberusoftware/settings",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-settings.git",
-                "reference": "9aa6651e136eb2e995d57d5d8f6bbcf477e3b326"
+                "reference": "37c18cd0aaa4d026b7adcfba859516dd7abc39aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-settings/zipball/9aa6651e136eb2e995d57d5d8f6bbcf477e3b326",
-                "reference": "9aa6651e136eb2e995d57d5d8f6bbcf477e3b326",
+                "url": "https://api.github.com/repos/liberusoftware/module-settings/zipball/37c18cd0aaa4d026b7adcfba859516dd7abc39aa",
+                "reference": "37c18cd0aaa4d026b7adcfba859516dd7abc39aa",
                 "shasum": ""
             },
             "require": {
@@ -7116,23 +7116,23 @@
             ],
             "description": "Typed scoped settings foundation for Liberu applications.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-settings/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-settings/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-settings/issues"
             },
-            "time": "2026-08-07T09:00:45+00:00"
+            "time": "2026-08-07T14:25:50+00:00"
         },
         {
             "name": "liberusoftware/settings-filament",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-settings-filament.git",
-                "reference": "f73d3139c0aefbac749d098544d35d0476e21ff8"
+                "reference": "86ee7e6377624baca845121981e6bb8cec092ca2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-settings-filament/zipball/f73d3139c0aefbac749d098544d35d0476e21ff8",
-                "reference": "f73d3139c0aefbac749d098544d35d0476e21ff8",
+                "url": "https://api.github.com/repos/liberusoftware/module-settings-filament/zipball/86ee7e6377624baca845121981e6bb8cec092ca2",
+                "reference": "86ee7e6377624baca845121981e6bb8cec092ca2",
                 "shasum": ""
             },
             "require": {
@@ -7174,23 +7174,23 @@
             ],
             "description": "Filament administration adapter for Liberu Settings.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-settings-filament/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-settings-filament/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-settings-filament/issues"
             },
-            "time": "2026-08-07T10:01:17+00:00"
+            "time": "2026-08-07T14:26:12+00:00"
         },
         {
             "name": "liberusoftware/theme-base",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/theme-base.git",
-                "reference": "070f460e13c5e62948d1460a17cd26c4d35a1c01"
+                "reference": "a79f3355a9dd7af74f080d66ea82f700cfac09b8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/theme-base/zipball/070f460e13c5e62948d1460a17cd26c4d35a1c01",
-                "reference": "070f460e13c5e62948d1460a17cd26c4d35a1c01",
+                "url": "https://api.github.com/repos/liberusoftware/theme-base/zipball/a79f3355a9dd7af74f080d66ea82f700cfac09b8",
+                "reference": "a79f3355a9dd7af74f080d66ea82f700cfac09b8",
                 "shasum": ""
             },
             "require": {
@@ -7227,23 +7227,23 @@
             ],
             "description": "Shared semantic tokens and accessible presentation primitives for Liberu themes.",
             "support": {
-                "source": "https://github.com/liberusoftware/theme-base/tree/2.0.0",
+                "source": "https://github.com/liberusoftware/theme-base/tree/2.0.1",
                 "issues": "https://github.com/liberusoftware/theme-base/issues"
             },
-            "time": "2026-08-07T09:37:23+00:00"
+            "time": "2026-08-07T14:25:52+00:00"
         },
         {
             "name": "liberusoftware/theme-clear-signal",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/theme-clear-signal.git",
-                "reference": "2a0bd2dd0a44fd5c2433f492076efcffe11a100a"
+                "reference": "e4f7e56bdf4edc722c59976acdf3acbf9757df28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/theme-clear-signal/zipball/2a0bd2dd0a44fd5c2433f492076efcffe11a100a",
-                "reference": "2a0bd2dd0a44fd5c2433f492076efcffe11a100a",
+                "url": "https://api.github.com/repos/liberusoftware/theme-clear-signal/zipball/e4f7e56bdf4edc722c59976acdf3acbf9757df28",
+                "reference": "e4f7e56bdf4edc722c59976acdf3acbf9757df28",
                 "shasum": ""
             },
             "require": {
@@ -7281,23 +7281,23 @@
             ],
             "description": "Clear Signal public theme for Liberu applications.",
             "support": {
-                "source": "https://github.com/liberusoftware/theme-clear-signal/tree/1.5.0",
+                "source": "https://github.com/liberusoftware/theme-clear-signal/tree/1.5.1",
                 "issues": "https://github.com/liberusoftware/theme-clear-signal/issues"
             },
-            "time": "2026-08-07T09:39:56+00:00"
+            "time": "2026-08-07T14:25:54+00:00"
         },
         {
             "name": "liberusoftware/theme-dark",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/theme-dark.git",
-                "reference": "8607a3cadd8fc0381202b69f94bf2d6960059374"
+                "reference": "d5d2027dd87a806cd4faee81ca798caf0ae75845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/theme-dark/zipball/8607a3cadd8fc0381202b69f94bf2d6960059374",
-                "reference": "8607a3cadd8fc0381202b69f94bf2d6960059374",
+                "url": "https://api.github.com/repos/liberusoftware/theme-dark/zipball/d5d2027dd87a806cd4faee81ca798caf0ae75845",
+                "reference": "d5d2027dd87a806cd4faee81ca798caf0ae75845",
                 "shasum": ""
             },
             "require": {
@@ -7335,23 +7335,23 @@
             ],
             "description": "Liberu dark public theme.",
             "support": {
-                "source": "https://github.com/liberusoftware/theme-dark/tree/1.5.0",
+                "source": "https://github.com/liberusoftware/theme-dark/tree/1.5.1",
                 "issues": "https://github.com/liberusoftware/theme-dark/issues"
             },
-            "time": "2026-08-07T09:39:11+00:00"
+            "time": "2026-08-07T14:26:22+00:00"
         },
         {
             "name": "liberusoftware/theme-default",
-            "version": "1.5.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/theme-default.git",
-                "reference": "b4d61c7b1f33739f1c68d21c8f3e5b1bd41db12a"
+                "reference": "759e19abeba7d39d129d6ce9acaa10d9d4e7da50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/theme-default/zipball/b4d61c7b1f33739f1c68d21c8f3e5b1bd41db12a",
-                "reference": "b4d61c7b1f33739f1c68d21c8f3e5b1bd41db12a",
+                "url": "https://api.github.com/repos/liberusoftware/theme-default/zipball/759e19abeba7d39d129d6ce9acaa10d9d4e7da50",
+                "reference": "759e19abeba7d39d129d6ce9acaa10d9d4e7da50",
                 "shasum": ""
             },
             "require": {
@@ -7389,23 +7389,23 @@
             ],
             "description": "Liberu default public theme.",
             "support": {
-                "source": "https://github.com/liberusoftware/theme-default/tree/1.5.0",
+                "source": "https://github.com/liberusoftware/theme-default/tree/1.5.1",
                 "issues": "https://github.com/liberusoftware/theme-default/issues"
             },
-            "time": "2026-08-07T09:39:11+00:00"
+            "time": "2026-08-07T14:26:23+00:00"
         },
         {
             "name": "liberusoftware/theme-support",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-theme-support.git",
-                "reference": "5273a969468cca99a854db84df467329bfa880b9"
+                "reference": "22c3d18d23d802265d68f03e58f8dda8b88b48fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-theme-support/zipball/5273a969468cca99a854db84df467329bfa880b9",
-                "reference": "5273a969468cca99a854db84df467329bfa880b9",
+                "url": "https://api.github.com/repos/liberusoftware/module-theme-support/zipball/22c3d18d23d802265d68f03e58f8dda8b88b48fa",
+                "reference": "22c3d18d23d802265d68f03e58f8dda8b88b48fa",
                 "shasum": ""
             },
             "require": {
@@ -7451,23 +7451,23 @@
             ],
             "description": "Theme discovery and host presentation support for Liberu applications.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-theme-support/tree/1.4.1",
+                "source": "https://github.com/liberusoftware/module-theme-support/tree/1.4.2",
                 "issues": "https://github.com/liberusoftware/module-theme-support/issues"
             },
-            "time": "2026-08-07T09:44:56+00:00"
+            "time": "2026-08-07T14:25:46+00:00"
         },
         {
             "name": "liberusoftware/theme-support-livewire",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-theme-support-livewire.git",
-                "reference": "d09e14302958a9e960fc538124a1b19418246c1e"
+                "reference": "8db221e424ebd0a1d9bbb61265b41878da59caeb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-theme-support-livewire/zipball/d09e14302958a9e960fc538124a1b19418246c1e",
-                "reference": "d09e14302958a9e960fc538124a1b19418246c1e",
+                "url": "https://api.github.com/repos/liberusoftware/module-theme-support-livewire/zipball/8db221e424ebd0a1d9bbb61265b41878da59caeb",
+                "reference": "8db221e424ebd0a1d9bbb61265b41878da59caeb",
                 "shasum": ""
             },
             "require": {
@@ -7507,23 +7507,23 @@
             ],
             "description": "Livewire theme-switching presentation adapter for Liberu Theme Support.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-theme-support-livewire/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-theme-support-livewire/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-theme-support-livewire/issues"
             },
-            "time": "2026-08-07T09:00:51+00:00"
+            "time": "2026-08-07T14:25:59+00:00"
         },
         {
             "name": "liberusoftware/two-factor-authentication",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-two-factor-authentication.git",
-                "reference": "34cd1d0d2b01bf4c35023fdf5bf1b7825aceb7c0"
+                "reference": "60e4cb036f76375e9814cf57ca4a32fc343301e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-two-factor-authentication/zipball/34cd1d0d2b01bf4c35023fdf5bf1b7825aceb7c0",
-                "reference": "34cd1d0d2b01bf4c35023fdf5bf1b7825aceb7c0",
+                "url": "https://api.github.com/repos/liberusoftware/module-two-factor-authentication/zipball/60e4cb036f76375e9814cf57ca4a32fc343301e5",
+                "reference": "60e4cb036f76375e9814cf57ca4a32fc343301e5",
                 "shasum": ""
             },
             "require": {
@@ -7562,23 +7562,23 @@
             ],
             "description": "TOTP enforcement policy and one-time recovery-code primitives.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-two-factor-authentication/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-two-factor-authentication/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-two-factor-authentication/issues"
             },
-            "time": "2026-08-07T09:00:49+00:00"
+            "time": "2026-08-07T14:25:56+00:00"
         },
         {
             "name": "liberusoftware/webhooks",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/liberusoftware/module-webhooks.git",
-                "reference": "823a7a92a2a04820c01cb85f0e151e3d37ae1d9a"
+                "reference": "308f905ee503c708dce8ffbb78a08c7c5b9d72bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/liberusoftware/module-webhooks/zipball/823a7a92a2a04820c01cb85f0e151e3d37ae1d9a",
-                "reference": "823a7a92a2a04820c01cb85f0e151e3d37ae1d9a",
+                "url": "https://api.github.com/repos/liberusoftware/module-webhooks/zipball/308f905ee503c708dce8ffbb78a08c7c5b9d72bb",
+                "reference": "308f905ee503c708dce8ffbb78a08c7c5b9d72bb",
                 "shasum": ""
             },
             "require": {
@@ -7617,10 +7617,10 @@
             ],
             "description": "Signed filtered webhook endpoints, durable delivery attempts, retry, replay, and secret rotation.",
             "support": {
-                "source": "https://github.com/liberusoftware/module-webhooks/tree/1.4.0",
+                "source": "https://github.com/liberusoftware/module-webhooks/tree/1.4.1",
                 "issues": "https://github.com/liberusoftware/module-webhooks/issues"
             },
-            "time": "2026-08-07T09:00:49+00:00"
+            "time": "2026-08-07T14:25:58+00:00"
         },
         {
             "name": "livewire/livewire",
@@ -9579,24 +9579,27 @@
         },
         {
             "name": "pusher/pusher-php-server",
-            "version": "7.2.8",
+            "version": "7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pusher/pusher-http-php.git",
-                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2"
+                "reference": "058d8464246118110a341fc2e6e70c7c8b6a7f2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/4aa139ed2a2a805cd265449b691198beee1309d2",
-                "reference": "4aa139ed2a2a805cd265449b691198beee1309d2",
+                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/058d8464246118110a341fc2e6e70c7c8b6a7f2c",
+                "reference": "058d8464246118110a341fc2e6e70c7c8b6a7f2c",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
-                "guzzlehttp/guzzle": "^7.2",
+                "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+                "guzzlehttp/promises": "^2.0.3 || ^3.0",
+                "guzzlehttp/psr7": "^2.6.3 || ^3.0",
                 "php": "^7.3|^8.0",
-                "psr/log": "^1.0|^2.0|^3.0"
+                "psr/http-client": "^1.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
                 "overtrue/phplint": "^2.3",
@@ -9633,9 +9636,9 @@
             ],
             "support": {
                 "issues": "https://github.com/pusher/pusher-http-php/issues",
-                "source": "https://github.com/pusher/pusher-http-php/tree/7.2.8"
+                "source": "https://github.com/pusher/pusher-http-php/tree/7.3.0"
             },
-            "time": "2026-05-18T13:11:36+00:00"
+            "time": "2026-08-07T12:47:11+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -16984,16 +16987,16 @@
         },
         {
             "name": "laravel/boost",
-            "version": "v2.5.2",
+            "version": "v2.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/boost.git",
-                "reference": "e4f651a973cb454616c36d324150b6a533913bd1"
+                "reference": "f5f9297225aba9857d014b3140f55a7c50cb1a92"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/boost/zipball/e4f651a973cb454616c36d324150b6a533913bd1",
-                "reference": "e4f651a973cb454616c36d324150b6a533913bd1",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/f5f9297225aba9857d014b3140f55a7c50cb1a92",
+                "reference": "f5f9297225aba9857d014b3140f55a7c50cb1a92",
                 "shasum": ""
             },
             "require": {
@@ -17046,20 +17049,20 @@
                 "issues": "https://github.com/laravel/boost/issues",
                 "source": "https://github.com/laravel/boost"
             },
-            "time": "2026-08-06T19:01:40+00:00"
+            "time": "2026-08-07T05:46:02+00:00"
         },
         {
             "name": "laravel/mcp",
-            "version": "v0.9.1",
+            "version": "v0.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/mcp.git",
-                "reference": "a08884d79a95c5143498507aec5badf751cdbec4"
+                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/mcp/zipball/a08884d79a95c5143498507aec5badf751cdbec4",
-                "reference": "a08884d79a95c5143498507aec5badf751cdbec4",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
+                "reference": "2bb70c3662dfc2e2ff55c38a10ddf55bed2443b3",
                 "shasum": ""
             },
             "require": {
@@ -17120,7 +17123,7 @@
                 "issues": "https://github.com/laravel/mcp/issues",
                 "source": "https://github.com/laravel/mcp"
             },
-            "time": "2026-07-21T13:23:52+00:00"
+            "time": "2026-08-06T15:59:47+00:00"
         },
         {
             "name": "laravel/pint",
@@ -17592,16 +17595,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v5.0.3",
+            "version": "v5.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "585de259a2e59d01ece1340f040d60bb52d2fb14"
+                "reference": "7b6415ccd07c1e68031fa47c0999ed680cf717bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/585de259a2e59d01ece1340f040d60bb52d2fb14",
-                "reference": "585de259a2e59d01ece1340f040d60bb52d2fb14",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/7b6415ccd07c1e68031fa47c0999ed680cf717bd",
+                "reference": "7b6415ccd07c1e68031fa47c0999ed680cf717bd",
                 "shasum": ""
             },
             "require": {
@@ -17610,7 +17613,7 @@
                 "nunomaduro/termwind": "^2.4.0",
                 "pestphp/pest-plugin": "^5.0.0",
                 "pestphp/pest-plugin-arch": "^5.0.0",
-                "pestphp/pest-plugin-mutate": "^5.0.0",
+                "pestphp/pest-plugin-mutate": "^5.0.1",
                 "pestphp/pest-plugin-profanity": "^5.0.0",
                 "php": "^8.4",
                 "phpunit/phpunit": "^13.2.6",
@@ -17623,12 +17626,11 @@
                 "webmozart/assert": "<1.11.0"
             },
             "require-dev": {
-                "laravel/pao": "^1.1.3",
                 "pestphp/pest-dev-tools": "^5.0.0",
                 "pestphp/pest-plugin-browser": "^5.0.0",
                 "pestphp/pest-plugin-phpstan": "^5.0.0",
-                "pestphp/pest-plugin-rector": "^5.0.0",
-                "pestphp/pest-plugin-type-coverage": "^5.0.0",
+                "pestphp/pest-plugin-rector": "^5.0.2",
+                "pestphp/pest-plugin-type-coverage": "^5.0.2",
                 "psy/psysh": "^0.12.24"
             },
             "bin": [
@@ -17696,7 +17698,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v5.0.3"
+                "source": "https://github.com/pestphp/pest/tree/v5.0.4"
             },
             "funding": [
                 {
@@ -17708,7 +17710,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-08-03T02:26:34+00:00"
+            "time": "2026-08-07T02:15:22+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -18420,16 +18422,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "14.2.4",
+            "version": "14.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4"
+                "reference": "060a5c93e81afb01e97dbe8930a5d0c9bd46e54e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/048a5c12bdb4580f4767ce2761793a16b170fbe4",
-                "reference": "048a5c12bdb4580f4767ce2761793a16b170fbe4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/060a5c93e81afb01e97dbe8930a5d0c9bd46e54e",
+                "reference": "060a5c93e81afb01e97dbe8930a5d0c9bd46e54e",
                 "shasum": ""
             },
             "require": {
@@ -18443,12 +18445,12 @@
                 "sebastian/complexity": "^6.0",
                 "sebastian/environment": "^9.3.2",
                 "sebastian/git-state": "^1.0",
-                "sebastian/lines-of-code": "^5.0.1",
+                "sebastian/lines-of-code": "^5.0.2",
                 "sebastian/version": "^7.0",
                 "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.2.2"
+                "phpunit/phpunit": "^13.3"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -18457,7 +18459,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "14.2.x-dev"
+                    "dev-main": "14.3.x-dev"
                 }
             },
             "autoload": {
@@ -18486,7 +18488,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.2.4"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/14.3.0"
             },
             "funding": [
                 {
@@ -18506,7 +18508,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-30T17:01:07+00:00"
+            "time": "2026-08-07T07:24:15+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -19024,16 +19026,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "8.3.0",
+            "version": "8.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c025fc7604afab3f195fab7cdaf72327331af241"
+                "reference": "3b070e608146cba00fd6fd1f0ffba89e5a8897fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c025fc7604afab3f195fab7cdaf72327331af241",
-                "reference": "c025fc7604afab3f195fab7cdaf72327331af241",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/3b070e608146cba00fd6fd1f0ffba89e5a8897fb",
+                "reference": "3b070e608146cba00fd6fd1f0ffba89e5a8897fb",
                 "shasum": ""
             },
             "require": {
@@ -19041,10 +19043,10 @@
                 "ext-mbstring": "*",
                 "php": ">=8.4",
                 "sebastian/diff": "^9.0",
-                "sebastian/exporter": "^8.1.0"
+                "sebastian/exporter": "^8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.2"
+                "phpunit/phpunit": "^13.3"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -19052,7 +19054,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.3-dev"
+                    "dev-main": "8.4-dev"
                 }
             },
             "autoload": {
@@ -19092,7 +19094,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/8.3.0"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/8.4.0"
             },
             "funding": [
                 {
@@ -19112,7 +19114,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-05T03:06:45+00:00"
+            "time": "2026-08-07T07:23:13+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -19341,30 +19343,30 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "8.1.1",
+            "version": "8.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26"
+                "reference": "24a3b69bba4a12ab615fca9d34680c5598d9ab7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
-                "reference": "cfaa77c750dcad6f44c9bac8f62ac486e1c82c26",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/24a3b69bba4a12ab615fca9d34680c5598d9ab7a",
+                "reference": "24a3b69bba4a12ab615fca9d34680c5598d9ab7a",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "php": ">=8.4",
-                "sebastian/recursion-context": "^8.0"
+                "sebastian/recursion-context": "^8.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^13.2.4"
+                "phpunit/phpunit": "^13.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.1-dev"
+                    "dev-main": "8.2-dev"
                 }
             },
             "autoload": {
@@ -19407,7 +19409,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/8.1.1"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/8.2.1"
             },
             "funding": [
                 {
@@ -19427,7 +19429,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-13T11:35:11+00:00"
+            "time": "2026-08-07T07:22:06+00:00"
         },
         {
             "name": "sebastian/file-filter",

--- a/docs/CODE-CONFORMANCE.md
+++ b/docs/CODE-CONFORMANCE.md
@@ -36,7 +36,7 @@ class between them while `TESTING.md` holds a quarter of another. The full per-s
 | Class | Clusters | Audited |
 | --- | --- | --- |
 | **Boundary** — a package can check it about itself | 34 | **yes, below** |
-| **CI** — decidable by a workflow step | 30 | not yet |
+| **CI** — decidable by a workflow step | 30 | **yes, below** |
 | **Arch** — whole-graph, needs every package in view | 11 | not yet |
 | **Larastan** | 6 | not yet |
 | **Pint** | 3 | not yet |
@@ -48,39 +48,42 @@ class between them while `TESTING.md` holds a quarter of another. The full per-s
 Measured against this tree on 2026-08-07: 40 `liberu-module` packages under `modules/`, 4
 `liberu-theme` packages under `themes/`, and the host.
 
-| Standard | Boundary class | Findings |
-| --- | --- | --- |
-| `API` | no Boundary rules | — |
-| `ADOPTION` | no Boundary rules | — |
-| `BLADE` | no Boundary rules | — |
-| `CI` | no Boundary rules | — |
-| `CLASSES` | no Boundary rules | — |
-| `CONCERNS` | no Boundary rules | — |
-| `CONTRACTS` | no Boundary rules | — |
-| `CONTRIBUTING` | no Boundary rules | — |
-| `CONTROLLERS` | no Boundary rules | — |
-| `DATABASE` | audited | **1** |
-| `DOCUMENTATION` | no Boundary rules | — |
-| `DOMAIN-DRIVEN-DESIGN-PATTERNS` | no Boundary rules | — |
-| `FILAMENT` | audited | **3** |
-| `FRONTEND-TESTING` | vacuous | — no JavaScript presentation package exists |
-| `GUIDELINES` | no Boundary rules | — |
-| `JOBS` | vacuous | — the fleet ships **no job classes at all** |
-| `LARAVEL` | audited | 0 |
-| `LIVEWIRE` | audited | **1** |
-| `MODELS` | audited | 0 — see the `DATABASE` finding |
-| `OBJECT-ORIENTED-PROGRAMMING` | no Boundary rules | — |
-| `PHP` | no Boundary rules | — |
-| `PINT` | audited | 0 |
-| `PSR` | audited | 0 |
-| `QUEUES` | vacuous | — no job classes |
-| `README` | index only | — |
-| `SERVICES` | no Boundary rules | — |
-| `TESTING` | audited | **1** |
-| `THEMES` | audited | **1** |
-| `TRANSLATIONS` | no Boundary rules | — |
-| `VIEWS` | no Boundary rules | — |
-| `FLUTTER` `INERTIA` `MOBILE` `NUXT` `REACT` `REACT-NATIVE` `VUE` | **inapplicable** | this stack has no React, Vue, Nuxt, Inertia, Flutter, React Native or mobile surface. Ruled out while charting, recorded here so the seven are not re-litigated |
+`—` means the standard states no rule in that class. A blank cell would be ambiguous between "clean"
+and "nobody looked", which is the confusion this table exists to prevent.
+
+| Standard | Boundary | CI | Findings so far |
+| --- | --- | --- | --- |
+| `ADOPTION` | — | — | — |
+| `API` | — | audited | **1** |
+| `BLADE` | — | audited | 0 |
+| `CI` | — | audited | **6** |
+| `CLASSES` | — | — | — |
+| `CONCERNS` | — | — | — |
+| `CONTRACTS` | — | — | — |
+| `CONTRIBUTING` | — | audited | 0 — its heading and link rules become checkable with the Markdown linter `DOCUMENTATION` asks for |
+| `CONTROLLERS` | — | — | — |
+| `DATABASE` | audited | audited | **2** |
+| `DOCUMENTATION` | — | audited | **1** |
+| `DOMAIN-DRIVEN-DESIGN-PATTERNS` | — | — | — |
+| `FILAMENT` | audited | audited | **4** |
+| `FRONTEND-TESTING` | vacuous | vacuous | — no JavaScript presentation package exists |
+| `GUIDELINES` | — | — | — |
+| `JOBS` | vacuous | vacuous | — the fleet ships **no job classes at all** |
+| `LARAVEL` | audited | — | 0 |
+| `LIVEWIRE` | audited | vacuous | **1** — no SFC/MFC and no islands, so both CI rules have an empty population |
+| `MODELS` | audited | — | 0 — see the `DATABASE` findings |
+| `OBJECT-ORIENTED-PROGRAMMING` | — | — | — |
+| `PHP` | — | audited | 0 |
+| `PINT` | audited | audited | 0 |
+| `PSR` | audited | audited | 0 |
+| `QUEUES` | vacuous | — | — no job classes |
+| `README` | index only | — | — |
+| `SERVICES` | — | — | — |
+| `TESTING` | audited | audited | **4** |
+| `THEMES` | audited | audited | **3** |
+| `TRANSLATIONS` | — | audited | **2** |
+| `VIEWS` | — | audited | 0 |
+| `FLUTTER` `INERTIA` `MOBILE` `NUXT` `REACT` `REACT-NATIVE` `VUE` | **inapplicable** | **inapplicable** | this stack has no React, Vue, Nuxt, Inertia, Flutter, React Native or mobile surface. Ruled out while charting, recorded here so the seven are not re-litigated |
 
 ## Boundary class — findings
 
@@ -124,8 +127,69 @@ then static analysis — were both silence mistaken for health.
   bind to. Recorded rather than reported as conformance, because passing a rule with an empty
   population is not evidence of anything.
 
+## CI class — findings
+
+Rules that are mechanically decidable but by a workflow step rather than by Pint or Larastan. All 17
+findings rank **unenforced**, and that is not a coincidence — see *What the ranks did not survive*
+below.
+
+| Rule | Population | Rank | Cost |
+| --- | --- | --- | --- |
+| **Third-party actions are not pinned to full-length commit SHAs.** `CI.md`, *Workflow security*: "Pin third-party actions to full-length commit SHAs". Every reference is a mutable tag — `actions/checkout@v5`, `shivammathur/setup-php@v2`, `actions/cache@v4`, `codecov/codecov-action@v5`, four `docker/*` actions | **21 references** across 4 host workflows and 3 reusable workflows | unenforced | 7 files, one PR each; then a renewal process, because pinned SHAs need updating |
+| **All 44 package callers pin the reusable workflow to `@main`.** A push to `liberusoftware/.github` changes every repository's CI instantly, with no staging. Demonstrated in this effort: adding a `--config` flag pointing at a not-yet-tagged file would have failed all 44 builds, and needed a guard commit rather than a rollback | 44 of 44 | unenforced | 44 files to pin, or a release process for the reusable workflows |
+| **`composer validate` and `composer audit` run only at tag time for packages.** They are in `package-install.yml`, which triggers on tags and `workflow_dispatch`. `CI.md` requires them on every pull request and every push to `main` | 44 of 44 packages | unenforced | one step each in `package-tests.yml` |
+| **Host `install.yml` declares no `permissions:` block.** `CI.md`: least-privilege, "normally starting with `contents: read`". The other three host workflows and all three reusable workflows declare one | 1 of 4 host workflows | unenforced | 2 lines |
+| **No secret scanning anywhere.** `CI.md` requires "dependency, secret, container, and supported security scans". Dependency scanning exists — `composer audit --locked` in the host, `composer audit` at package release. The other two do not | host + 44 packages | unenforced | one workflow, fleet-wide via the reusable caller |
+| **`docker.yml` builds and publishes without scanning.** `CI.md` assigns it "Build, scan, and publish immutable container artifacts" | 1 host workflow | unenforced | one step |
+| **The seven translation checks named by `TRANSLATIONS.md` do not exist.** Key uniqueness, placeholder parity, missing keys, invalid plural forms, encoding, stale keys, locale coverage — the standard names them individually as CI's job | 4 locales, every module owning message keys | unenforced | unknown — no tool is chosen |
+| **No pseudo-localization or RTL browser tests.** `TRANSLATIONS.md` requires both to verify expansion, truncation, focus order and screen-reader announcements | fleet-wide | unenforced | unknown |
+| **No Markdown lint or link checking.** `DOCUMENTATION.md` §12 asks CI to "lint Markdown, check internal and external links, validate headings and code fences" | host + 44 package READMEs | unenforced | one workflow; `CONTRIBUTING.md`'s heading and link rules become checkable with it |
+| **No OpenAPI document exists.** `API.md` and `DOCUMENTATION.md` §9 require reference material generated from or checked against a versioned contract, plus drift and breaking-change detection. The fleet ships an `api-access` module | 1 module | unenforced | unknown — writing the contract is the work, not the check |
+| **No `visual.yml` in any theme.** `THEMES.md` §18.1 names four required theme workflows; all four themes ship `install.yml`, `tests.yml` and `compatibility.yml` | 4 of 4 themes | unenforced | 4 repositories + a release wave; the accessibility and visual-regression tooling is the unknown |
+| **`test:coverage` does not enforce `--min=100`.** `THEMES.md` §18 specifies the exact command with Clover and HTML output. No theme declares the script at all | 4 of 4 themes | unenforced | trivial to declare, unreachable to satisfy — theme coverage is far below 100 |
+| **The package workflow produces no coverage artifact.** `TESTING.md` §13 requires a machine-readable report for quality services and an HTML report for diagnosis, retained as protected CI artifacts. The host uploads to Codecov; no package produces anything | 44 of 44 | unenforced | two steps in `package-tests.yml` |
+| **No README coverage or CI-status badge.** `TESTING.md` §13: "The README badge must reflect the default branch and link to its maintained report". READMEs carry PHP, release and licence badges | 44 of 44 | unenforced | 44 README edits; blocked on the artifact row above |
+| **No release-scope coverage gate.** `CI.md` and `TESTING.md` §13 make 100% of release scope a release gate. Nothing checks it, and the fleet's per-package ratchet is a migration state by the standard's own words | release process | unenforced | unknown — the gate is meaningless until the ratchet approaches 100 |
+| **Nothing checks that a released migration is never edited.** `DATABASE.md` states the rule; it is mechanically decidable by diffing `database/migrations/` against the last release tag | 40 modules | unenforced | one step in `package-tests.yml` |
+| **`-filament` READMEs document almost none of the required inventory.** `FILAMENT.md` §20 names ~18 items including the panel matrix, typed configuration options, resource/page/widget inventory, and discovery namespaces. A measured README has 12 headings, none of them these | 6 of 6 `-filament` packages | unenforced | 6 READMEs; blocked on the panel matrix not existing (a Boundary finding) |
+
+## CI class — conformance
+
+| Rule | Evidence |
+| --- | --- |
+| Least-privilege `permissions:` | **3 of 4** host workflows and **3 of 3** reusable workflows declare `contents: read`; `release.yml` correctly widens to `contents: write` |
+| `composer validate` and `composer audit` at release | present in `package-install.yml`; the host runs `composer validate --strict` and `composer audit --locked` on every push. `--strict` is deliberately not used for packages — it errors on the `version` field, which this fleet requires because `ModuleValidator` compares manifests against `Composer\InstalledVersions` |
+| CI fails on unexpected `modules/` or `themes/` changes | **enforced** — the §6.2 zero-diff gate in the host's `install.yml` |
+| The release workflow tests the commit it deploys | `release.yml` triggers on the tag and uses `--verify-tag`; no rebuild from a different ref |
+| No `eval`, `unserialize`, `extract`, or bare `catch (Exception)` in owned source | **0 occurrences** across `modules/*/src`, `themes/*/src` and `app/` |
+| Framework cryptography rather than custom primitives | one `md5()` in the fleet, a cache-key hash in `localization-mymemory`, not a security primitive |
+| `@csrf` present where forms are | **7 of 7** files containing `<form>` |
+| Escaped output by default | **3** `{!! !!}` uses, all in the host: two are `$attributes->merge()` in form components, one is a translation string with link placeholders. None interpolates request input |
+| SFC/MFC filenames free of the bolt emoji (`LIVEWIRE.md` §6) | **0** — vacuous, the fleet ships no SFC/MFC |
+| Islands not placed inside loops or conditionals (`LIVEWIRE.md` §17) | **0 islands** — vacuous |
+
+## What the ranks did not survive
+
+**Every CI finding ranks *unenforced*, and the rank therefore carries no information here.** That is
+structural: this class is defined as *decidable by a workflow step*, so its failure mode is always
+"no workflow step does it", which is the definition of *unenforced*. The rank separates findings
+usefully in the Boundary class — 1 consumer, 2 promise, 3 unenforced, 1 style — and degenerates in
+this one.
+
+Two rows are also ranked lower than they deserve, both flagged when the ranks were settled:
+
+- **Unpinned actions** is a live supply-chain exposure — a moved tag executes arbitrary code in CI —
+  with no consumer-visible symptom and nothing false claimed. *Unenforced* undersells it.
+- **`@main` on the reusable workflow** has the same shape, and this effort produced the near-miss
+  that proves it.
+
+Two candidates were named when the ranks were defined as the trigger for adding a **security** rank.
+This is the second, and it is the same shape as the first. The recommendation is on the record here
+rather than acted on, because ranking is a settled decision and re-opening it is the map's call, not
+the audit's.
+
 ## Not yet audited
 
-CI (30 clusters), Arch (11), Larastan (6), Pint (3) and Prose (fleet) (38). Each is its own ticket
-under the map. Until those land, a standard marked *no Boundary rules* above has been **classified,
-not audited** — its rules live in a class this document has not reached.
+Arch (11 clusters), Larastan (6), Pint (3) and Prose (fleet) (38). Each is its own ticket under the
+map. Until those land, a standard marked *no Boundary rules* or *no CI rules* above has been
+**classified, not audited** — its rules live in a class this document has not reached.

--- a/docs/CODE-CONFORMANCE.md
+++ b/docs/CODE-CONFORMANCE.md
@@ -1,0 +1,131 @@
+# Code-level conformance audit
+
+Where this fleet stands against the code-level standards in
+[liberusoftware/documentation](https://github.com/liberusoftware/documentation) `standards/`.
+
+**This document fixes nothing.** Each finding is its own decision, taken afterwards with the
+measurement in hand. Charted as
+[Wayfinder: audit boilerplate-laravel against the Liberu code-level standards](https://github.com/liberusoftware/boilerplate-laravel/issues/642);
+the predecessor effort's structural conformance is `CONFORMANCE.md`.
+
+## How to read a finding
+
+A finding is one **rule**, the **population** it fails in, and the **size** of that population. A rule
+violated in 400 files is one row with a count, not four hundred rows. The fourth column is **cost** —
+the shape and size of the work — not a prescribed fix, because prescribing the fix would pre-empt the
+decision this document exists to inform. `unknown` is a legitimate cost.
+
+| Rank | Test |
+| --- | --- |
+| **breaks a consumer** | someone who installs or uses the package hits it |
+| **breaks a promise** | the repository asserts something untrue — a README, a manifest, `CLAUDE.md`, `CONFORMANCE.md` |
+| **unenforced** | the standard demands a check or property nothing guarantees; not necessarily wrong today |
+| **style only** | violated, no behavioural consequence |
+
+There is no *breaks a test* rank. The fleet's CI is green, so anything that broke a test would
+already be red and would be a bug report rather than an audit finding. Settled in
+[Define what a finding is, and how findings rank](https://github.com/liberusoftware/boilerplate-laravel/issues/645).
+
+## How the audit is sliced
+
+Not per standard. Every rule in the corpus was classified by the **mechanism that could catch it**,
+and the classes cut across the files — `FILAMENT.md`, `LIVEWIRE.md` and `THEMES.md` hold most of one
+class between them while `TESTING.md` holds a quarter of another. The full per-standard tables are in
+[the rule classification](https://github.com/liberusoftware/boilerplate-laravel/blob/research/standards-classification/docs/research/standards-rule-classification.md).
+
+| Class | Clusters | Audited |
+| --- | --- | --- |
+| **Boundary** — a package can check it about itself | 34 | **yes, below** |
+| **CI** — decidable by a workflow step | 30 | not yet |
+| **Arch** — whole-graph, needs every package in view | 11 | not yet |
+| **Larastan** | 6 | not yet |
+| **Pint** | 3 | not yet |
+| **Prose (fleet)** — a standing property the audit can state | 38 | not yet |
+| **Prose (per-change)** | 104 | **out of scope** — an obligation on the next change, with no fleet-wide fact behind it. An audit row for one cannot fail |
+
+## Standard status
+
+Measured against this tree on 2026-08-07: 40 `liberu-module` packages under `modules/`, 4
+`liberu-theme` packages under `themes/`, and the host.
+
+| Standard | Boundary class | Findings |
+| --- | --- | --- |
+| `API` | no Boundary rules | — |
+| `ADOPTION` | no Boundary rules | — |
+| `BLADE` | no Boundary rules | — |
+| `CI` | no Boundary rules | — |
+| `CLASSES` | no Boundary rules | — |
+| `CONCERNS` | no Boundary rules | — |
+| `CONTRACTS` | no Boundary rules | — |
+| `CONTRIBUTING` | no Boundary rules | — |
+| `CONTROLLERS` | no Boundary rules | — |
+| `DATABASE` | audited | **1** |
+| `DOCUMENTATION` | no Boundary rules | — |
+| `DOMAIN-DRIVEN-DESIGN-PATTERNS` | no Boundary rules | — |
+| `FILAMENT` | audited | **3** |
+| `FRONTEND-TESTING` | vacuous | — no JavaScript presentation package exists |
+| `GUIDELINES` | no Boundary rules | — |
+| `JOBS` | vacuous | — the fleet ships **no job classes at all** |
+| `LARAVEL` | audited | 0 |
+| `LIVEWIRE` | audited | **1** |
+| `MODELS` | audited | 0 — see the `DATABASE` finding |
+| `OBJECT-ORIENTED-PROGRAMMING` | no Boundary rules | — |
+| `PHP` | no Boundary rules | — |
+| `PINT` | audited | 0 |
+| `PSR` | audited | 0 |
+| `QUEUES` | vacuous | — no job classes |
+| `README` | index only | — |
+| `SERVICES` | no Boundary rules | — |
+| `TESTING` | audited | **1** |
+| `THEMES` | audited | **1** |
+| `TRANSLATIONS` | no Boundary rules | — |
+| `VIEWS` | no Boundary rules | — |
+| `FLUTTER` `INERTIA` `MOBILE` `NUXT` `REACT` `REACT-NATIVE` `VUE` | **inapplicable** | this stack has no React, Vue, Nuxt, Inertia, Flutter, React Native or mobile surface. Ruled out while charting, recorded here so the seven are not re-litigated |
+
+## Boundary class — findings
+
+| Rule | Population | Rank | Cost |
+| --- | --- | --- | --- |
+| **Livewire component aliases are not package-qualified.** `LIVEWIRE.md` §3 requires `module-{scope}::{component}`; both packages register a bare global name — `Livewire::component('language-switcher', …)` and `'theme-switcher'`. §3 also requires duplicates to fail rather than last-write-wins; a bare alias silently loses to any consumer registering the same name | 2 of 2 `-livewire` packages | **breaks a consumer** | 2 packages + every mount site. Cheap today: `CLAUDE.md` records that `<livewire:language-switcher />` is not mounted anywhere yet |
+| **`identity-core-filament` does not depend on the module it is named for.** `FILAMENT.md` §3.1 requires a one-to-one match with its domain module. It requires `roles-permissions` and **not** `identity-core`. Its `UserResource` resolves the model from `config('auth.providers.users.model')`, so it presents a model no module in its dependency graph owns | 1 of 6 `-filament` packages | **breaks a promise** | 1 package, a `require` line; unknown whether the resource then belongs there at all |
+| **Composer basename and installer name lack the `module-` prefix.** `FILAMENT.md` §2 and `LIVEWIRE.md` §2 apply the rule to "the independent GitHub repository name, Composer package basename, Liberu installer name, and installed directory". The repositories carry it; the Packagist names and installed directories do not. `CONFORMANCE.md` §6 states **"ADR exceptions: None"** while this exception is in force and undocumented | 8 presentation packages — 6 `-filament`, 2 `-livewire` | **breaks a promise** | either 8 renames + a release wave and every consuming `composer.json`, or one ADR. The naming decision itself is `CONFORMANCE.md` §3.3 |
+| **Plugin IDs do not equal the installer name.** `FILAMENT.md` §2: "Plugin IDs are stable kebab-case identifiers equal to the installer name". Measured: `liberu-identity` / `identity-core-filament`, `liberu-organizations` / `organizations-teams-filament`, `liberu-settings` / `settings-filament`, `liberu-sessions-devices` / `sessions-devices-filament`, `liberu-module-manager` / `module-manager-filament` | 5 of 6 `-filament` packages — the sixth inherits Shield's ID | **style only** | nothing breaks today, but a plugin ID is public surface: changing five is a major release each |
+| **Three packages migrate a table none of them owns.** `profiles`, `search` and `identity-socialstream` all `Schema::table('users', …)`. `DATABASE.md` forbids depending on migration order from another independent package without an explicit dependency contract; all three declare `identity-core`, which does not create `users` either. Ordering between them is currently accidental — `search` 2026-02-14, `profiles` 2026-02-16, `identity-socialstream` 2026-06-29 | 3 of 40 modules | **unenforced** | unknown. `CLAUDE.md` already records this as deliberate: `users` "is the one thing no package owns" |
+| **Four of five Composer script aliases missing.** `THEMES.md` §3.1.1 and `TESTING.md` §14 require `test`, `test:unit`, `test:feature`, `test:coverage`, `test:parallel`. Every package declares `"test": "pest"` and nothing else | 44 of 44 packages, and the host | **unenforced** | 44 `composer.json` edits + a release wave; mechanical |
+| **Themes do not declare `pestphp/pest-plugin-laravel`.** `THEMES.md` §3.1.1 names it in the canonical `require-dev`. All four declare `package-testbench` + `pest` only | 4 of 4 themes | **unenforced** | 4 `composer.json` edits + a release wave |
+
+## Boundary class — conformance
+
+Recorded because silence is not evidence. The predecessor effort's two largest findings — coverage,
+then static analysis — were both silence mistaken for health.
+
+| Rule | Evidence |
+| --- | --- |
+| One class, interface, trait or enum per file (`PSR.md`) | **216 source files, 0 violations** |
+| No package ships a `PanelProvider` (`FILAMENT.md` §7) | **0 of 44** — panels stay in the host |
+| Discovery is bounded; nothing scans the app, `/modules`, `/themes` or `/vendor` (`FILAMENT.md` §9.1) | **0** `discoverResources`/`discoverPages`/`discoverWidgets` calls anywhere |
+| Plugin class is final and offers `make()` (`FILAMENT.md` §8) | **6 of 6** final; **6 of 6** declare `make()` |
+| `phpunit.xml` committed (`TESTING.md` §3) | **44 of 44** |
+| `pestphp/pest ^5.0` in `require-dev` (`TESTING.md` §3) | **44 of 44**, exact constraint |
+| `phpunit/phpunit` **not** required separately (`TESTING.md` §3) | **0 of 44** do — though **the host does**, at `^13.1.8`. That is a CI-class row, audited later |
+| Manifest, provider, parent chain, cycles and asset paths validated (`THEMES.md` §18) | enforced continuously by `ThemeBoundaryTest` in `liberusoftware/package-testbench`, run by every theme against its own files |
+| Themes own no functional widgets (`FILAMENT.md` §12) | **0** widget classes in theme source. A recursive search of `themes/` matches 18, but every one is inside an untracked local `vendor/` left by running a theme's suite — scope the check to `themes/*/src` |
+| Composer type and install path (`FILAMENT.md` §4) | **6 of 6** `-filament` declare `liberu-module`; installer names match their directories |
+
+## Recorded deviations, not findings
+
+- **`roles-permissions-filament` extends `FilamentShieldPlugin`** rather than implementing Filament's
+  plugin contract directly, and inherits Shield's plugin ID. `FILAMENT.md` §8 asks for one final
+  plugin class implementing the contract. This is deliberate and already documented in `CLAUDE.md`:
+  the module wraps Shield with tenant resource scoping disabled, because Spatie already isolates
+  roles by `team_id`. The class is still `final`.
+- **`JOBS.md` and `QUEUES.md` boundary rules are vacuous here.** The fleet ships no job classes, so
+  "declare explicit connection, queue, timeout, `tries`, `backoff`, `maxExceptions`" has nothing to
+  bind to. Recorded rather than reported as conformance, because passing a rule with an empty
+  population is not evidence of anything.
+
+## Not yet audited
+
+CI (30 clusters), Arch (11), Larastan (6), Pint (3) and Prose (fleet) (38). Each is its own ticket
+under the map. Until those land, a standard marked *no Boundary rules* above has been **classified,
+not audited** — its rules live in a class this document has not reached.

--- a/docs/CODE-CONFORMANCE.md
+++ b/docs/CODE-CONFORMANCE.md
@@ -48,9 +48,9 @@ class between them while `TESTING.md` holds a quarter of another. The full per-s
 | --- | --- | --- |
 | **Boundary** — a package can check it about itself | 34 | **yes, below** |
 | **CI** — decidable by a workflow step | 30 | **yes, below** |
-| **Arch** — whole-graph, needs every package in view | 11 | not yet |
-| **Larastan** | 6 | not yet |
-| **Pint** | 3 | not yet |
+| **Arch** — whole-graph, needs every package in view | 11 | **yes, below** |
+| **Larastan** | 6 | **yes, below** |
+| **Pint** | 3 | **yes, below** |
 | **Prose (fleet)** — a standing property the audit can state | 38 | **yes, below** |
 | **Prose (per-change)** | 104 | **out of scope** — an obligation on the next change, with no fleet-wide fact behind it. An audit row for one cannot fail |
 
@@ -68,7 +68,7 @@ and "nobody looked", which is the confusion this table exists to prevent.
 | `API` | — | audited | **2** |
 | `BLADE` | — | audited | 0 |
 | `CI` | — | audited | **6** |
-| `CLASSES` | — | — | — |
+| `CLASSES` | — | — | **1** |
 | `CONCERNS` | — | — | 0 |
 | `CONTRACTS` | — | — | **1** |
 | `CONTRIBUTING` | — | audited | 0 — its heading and link rules become checkable with the Markdown linter `DOCUMENTATION` asks for |
@@ -81,17 +81,17 @@ and "nobody looked", which is the confusion this table exists to prevent.
 | `GUIDELINES` | — | — | — |
 | `JOBS` | vacuous | vacuous | — the fleet ships **no job classes at all** |
 | `LARAVEL` | audited | — | 0 |
-| `LIVEWIRE` | audited | vacuous | **1** — no SFC/MFC and no islands, so both CI rules have an empty population |
+| `LIVEWIRE` | audited | vacuous | **2** — no SFC/MFC and no islands, so both CI rules have an empty population |
 | `MODELS` | audited | — | 0 — see the `DATABASE` findings |
 | `OBJECT-ORIENTED-PROGRAMMING` | — | — | — |
-| `PHP` | — | audited | 0 |
+| `PHP` | — | audited | **3** |
 | `PINT` | audited | audited | 0 |
-| `PSR` | audited | audited | **1** |
+| `PSR` | audited | audited | **2** |
 | `QUEUES` | vacuous | — | — no job classes |
 | `README` | index only | — | — |
 | `SERVICES` | — | — | — |
 | `TESTING` | audited | audited | **4** |
-| `THEMES` | audited | audited | **4** |
+| `THEMES` | audited | audited | **5** |
 | `TRANSLATIONS` | — | audited | **2** |
 | `VIEWS` | — | audited | 0 |
 | `FLUTTER` `INERTIA` `MOBILE` `NUXT` `REACT` `REACT-NATIVE` `VUE` | **inapplicable** | **inapplicable** | this stack has no React, Vue, Nuxt, Inertia, Flutter, React Native or mobile surface. Ruled out while charting, recorded here so the seven are not re-litigated |
@@ -204,6 +204,40 @@ can be wrong. This is the class that needed reading rather than tooling.
 | Consent before analytics scripts (`THEMES.md` §16) | 13 references to consent across the analytics modules |
 | Create only the test suites the repository needs (`TESTING.md` §4) | the fleet uses `Feature` (9), `Unit` (8) and `Fixtures` (4) of the nine suites the standard lists. The standard says "Create only suites the repository needs"; the shared boundary suite covers the rest, per `CONFORMANCE.md` §3.7 |
 
+## Tool classes — findings
+
+Pint (3 clusters), Larastan (6) and whole-graph Arch (11), audited together because they share one
+property: **once the tool runs, the audit is a report rather than a reading**. All 44 packages now
+carry a measured PHPStan level and run both tools in CI, so these figures are continuous rather than
+a snapshot.
+
+| Rule | Population | Rank | Cost |
+| --- | --- | --- | --- |
+| **Seven packages call members their declared type does not have.** Every package capped at PHPStan level 1 fails level 2 on `property.notFound` / `method.notFound`. `jetstream-bridge` is the clearest: it type-hints `Illuminate\Foundation\Auth\User`, then calls `deleteProfilePhoto()`, `teams()`, `$connectedAccounts`, `$tokens`, `$ownedTeams` — members only the *host's* `User` has, through traits the package neither requires nor declares. A consumer whose `User` lacks them gets a fatal, not a diagnostic | 7 of 40 modules | **breaks a consumer** | per package: declare the shape it needs as a contract, or narrow the call. `search` is one line; `jetstream-bridge` is a design question |
+| **`search` still declares a return type that resolves to nothing.** `SearchService::searchUsers()` returns `Liberu\Foundation\Search\Services\User` — a bare `User` in the package's own namespace, `class.notFound`. Surfaced by the first ticket on this map and still shipping | 1 of 40 modules | **breaks a consumer** | one `use` statement, or one contract |
+| **`theme-support` cannot be analysed above level 1 because booting it throws.** `Error: Theme directory/name collision detected.` during the analysis boot. Its measured level is a floor imposed by a boot-time exception rather than a type ceiling, so its ratchet cannot move until the boot is fixed | 1 of 40 modules | **breaks a consumer** | unknown — why the collision check fires in a standalone context needs diagnosing first |
+| **`declare(strict_types=1);` is absent almost everywhere.** `PHP.md` requires it in new executable files and `PSR.md` repeats it. Measured: **3 of 216** package source files and **0 of 5** host files. Pint can enforce it, but `declare_strict_types` is **not in the `laravel` preset**, so the shared `pint.json` would have to add it | 213 of 216 package files, 5 of 5 host files | unenforced | one sweep rewrites 213 files — but strict types change coercion, so this is a **fleet-wide semantic change**, not a formatting one |
+| **18 packages stop at level 5, and the wall is missing type hints.** Level 6 is where PHPStan begins reporting them, and it is the modal ceiling across the fleet. `PHP.md` requires "typed properties, parameters, and return values" | 18 of 44 packages | unenforced | the ratchet moves one package at a time; no single change clears it |
+| **The service-locator prohibition has no rule, and is violated.** `CLASSES.md` forbids service-locator calls and static mutable state. Measured in package `src/`, excluding providers and presentation: **18** `app()`/`resolve()` call sites and **30 files** importing an `Illuminate\Support\Facades\*` class. No stock PHPStan rule catches this; a custom rule banning them in domain namespaces would | 30 of 216 files | unenforced | a custom PHPStan rule in the testbench, then the call sites |
+| **Four whole-graph properties the standards demand have no rule.** The host suite holds 8, and none covers: Livewire alias and full-page route collision (`LIVEWIRE.md` §3), a package silently claiming `/`, `/dashboard` or `/admin` (§10), the Blade-to-Livewire boundary (`BLADE.md`), or Filament's one-to-one module ownership (`FILAMENT.md` §3.1, already a Boundary finding) | host suite | unenforced | one rule each; the route-claim rule is the cheapest and catches a real class of collision |
+
+## Tool classes — conformance
+
+| Rule | Evidence |
+| --- | --- |
+| PSR-12 formatting (`PINT.md`, `PSR.md`) | **44 of 44** packages pass the shared ruleset, enforced on every push. No package carries a competing `pint.json` |
+| Every package is analysable | **44 of 44** measured, **none failed level 0** — no package has an error that no level relaxes |
+| Static analysis reaches the whole fleet | 11 packages at level 10, 1 at 9, 1 at 8, 18 at 5, 2 at 4, 1 at 3, 2 at 2, 8 at 1 — all ratcheted, none lowerable |
+| Composer owns every autoload boundary; no directory scanning | host architecture rule, passing |
+| One Composer vendor across the fleet | host architecture rule, passing |
+| Every package installs standalone | host architecture rule, passing |
+| Enablement derives from manifests, not a config list | host architecture rule, passing |
+| Every declared Filament plugin class exists | host architecture rule, passing |
+| Cross-package namespace dependencies declared in Composer | host architecture rule, passing |
+| Every declared theme parent resolves | host architecture rule, passing |
+| No dynamic properties | caught by the levels; **0** across the fleet |
+| Database access in controllers · live models in job constructors | **vacuous** — 2 controllers fleet-wide, 0 job classes |
+
 ## Where the ranks strained, and what was decided
 
 **Every CI finding ranks *unenforced*.** That is structural, not a defect: the class is defined as
@@ -225,7 +259,12 @@ were settled, the first was named as the precedent to point at if a second of th
 appeared; the CI audit produced it. The flag, rather than a fifth rank, keeps the rank axis meaning
 realized consequence — and left 22 findings unchanged.
 
-## Not yet audited
+## Audit complete
 
-Arch (11 clusters), Larastan (6) and Pint (3). Each is its own ticket under the map. Until those land, a standard marked *no Boundary rules* or *no CI rules* above has been
-**classified, not audited** — its rules live in a class this document has not reached.
+All six auditable classes are done — Boundary (34 clusters), CI (30), Prose (fleet) (38), Arch (11),
+Larastan (6) and Pint (3): **122 of 226 rule clusters**. The remaining 104 are Prose (per-change),
+ruled out of scope because an obligation on the next change has no fleet-wide fact behind it, and an
+audit row for one cannot fail.
+
+Every standard in the corpus now has a status above, clean ones included. **This document fixes
+nothing** — each finding is a decision still to take, with the measurement in hand.

--- a/docs/CODE-CONFORMANCE.md
+++ b/docs/CODE-CONFORMANCE.md
@@ -51,7 +51,7 @@ class between them while `TESTING.md` holds a quarter of another. The full per-s
 | **Arch** — whole-graph, needs every package in view | 11 | not yet |
 | **Larastan** | 6 | not yet |
 | **Pint** | 3 | not yet |
-| **Prose (fleet)** — a standing property the audit can state | 38 | not yet |
+| **Prose (fleet)** — a standing property the audit can state | 38 | **yes, below** |
 | **Prose (per-change)** | 104 | **out of scope** — an obligation on the next change, with no fleet-wide fact behind it. An audit row for one cannot fail |
 
 ## Standard status
@@ -64,17 +64,17 @@ and "nobody looked", which is the confusion this table exists to prevent.
 
 | Standard | Boundary | CI | Findings so far |
 | --- | --- | --- | --- |
-| `ADOPTION` | — | — | — |
-| `API` | — | audited | **1** |
+| `ADOPTION` | — | — | 0 |
+| `API` | — | audited | **2** |
 | `BLADE` | — | audited | 0 |
 | `CI` | — | audited | **6** |
 | `CLASSES` | — | — | — |
-| `CONCERNS` | — | — | — |
-| `CONTRACTS` | — | — | — |
+| `CONCERNS` | — | — | 0 |
+| `CONTRACTS` | — | — | **1** |
 | `CONTRIBUTING` | — | audited | 0 — its heading and link rules become checkable with the Markdown linter `DOCUMENTATION` asks for |
-| `CONTROLLERS` | — | — | — |
+| `CONTROLLERS` | — | — | 0 |
 | `DATABASE` | audited | audited | **2** |
-| `DOCUMENTATION` | — | audited | **1** |
+| `DOCUMENTATION` | — | audited | **3** |
 | `DOMAIN-DRIVEN-DESIGN-PATTERNS` | — | — | — |
 | `FILAMENT` | audited | audited | **4** |
 | `FRONTEND-TESTING` | vacuous | vacuous | — no JavaScript presentation package exists |
@@ -86,12 +86,12 @@ and "nobody looked", which is the confusion this table exists to prevent.
 | `OBJECT-ORIENTED-PROGRAMMING` | — | — | — |
 | `PHP` | — | audited | 0 |
 | `PINT` | audited | audited | 0 |
-| `PSR` | audited | audited | 0 |
+| `PSR` | audited | audited | **1** |
 | `QUEUES` | vacuous | — | — no job classes |
 | `README` | index only | — | — |
 | `SERVICES` | — | — | — |
 | `TESTING` | audited | audited | **4** |
-| `THEMES` | audited | audited | **3** |
+| `THEMES` | audited | audited | **4** |
 | `TRANSLATIONS` | — | audited | **2** |
 | `VIEWS` | — | audited | 0 |
 | `FLUTTER` `INERTIA` `MOBILE` `NUXT` `REACT` `REACT-NATIVE` `VUE` | **inapplicable** | **inapplicable** | this stack has no React, Vue, Nuxt, Inertia, Flutter, React Native or mobile surface. Ruled out while charting, recorded here so the seven are not re-litigated |
@@ -179,6 +179,31 @@ Two carry the **⚠ security** flag.
 | SFC/MFC filenames free of the bolt emoji (`LIVEWIRE.md` §6) | **0** — vacuous, the fleet ships no SFC/MFC |
 | Islands not placed inside loops or conditionals (`LIVEWIRE.md` §17) | **0 islands** — vacuous |
 
+## Prose (fleet) class — findings
+
+Judgement, but about a standing property of the fleet — so the audit can state it and the statement
+can be wrong. This is the class that needed reading rather than tooling.
+
+| Rule | Population | Rank | Cost |
+| --- | --- | --- | --- |
+| **Both analytics adapters are inert, and nothing says so.** `analytics-google` and `analytics-meta` register their destination only `if ($this->app->bound(GoogleTransport::class))` / `MetaTransport::class`. **Nothing in the fleet or the host binds either**, so enabling one registers no destination and sends nothing. Their READMEs list the contract file but never state that a consumer must implement and bind it, and `CLAUDE.md` says only that they "need third-party credentials" — they need an implementation as well | 2 of 40 modules | **breaks a promise** | 2 READMEs and one `CLAUDE.md` sentence, if documenting is the answer; a reference transport each if it is not |
+| **`CLAUDE.md` describes a domain-doc layout that does not exist.** Its *Domain docs* section declares single-context: "one root `CONTEXT.md` and one `docs/adr/`". Neither path is present. `DOCUMENTATION.md` §3 makes ADRs the source of truth for architectural decisions, and `CONFORMANCE.md` §6 resolves exceptions by pointing at ADRs that have no home | host | **breaks a promise** | either create both, or correct `CLAUDE.md`. The decision is which |
+| **11 of 23 declared interfaces have no implementation anywhere** — not in any package, not in the host. `ActivityAuthorizer`, `ExchangeRateProvider`, `GoogleTransport`, `IntegrationAdapter`, `MediaAccess`, `MediaTransformer`, `MetaTransport`, `ReadinessCheck`, `SettingDefinition`, `TransferAuthorizer`, `TwoFactorRecovery`. `CONTRACTS.md`: "Add one when substitution, testing, integration, or versioned extension is real — not for every class." Several are legitimate consumer extension points; others are provider-shaped contracts with no adapter, which `CONFORMANCE.md` §3.3 already acknowledges for `currency-context` | 11 of 23 interfaces, across 9 modules | style only | per interface: keep and document as an extension point, or delete. Each is public surface that must be versioned either way |
+| **No RFC 9457 Problem Details anywhere.** `API.md` requires "RFC 9457-compatible errors where defined by the ecosystem". `api-access` produces none, and `bootstrap/app.php` renders `api/*` exceptions in Laravel's default shape | 1 module + host | unenforced | one exception renderer; the contract shape is the decision |
+| **Theme tokens do not cover the eight required states.** `THEMES.md` §6: tokens must cover "light, dark, high-contrast, error, warning, success, disabled, and focus". `base` defines error, warning, success, disabled and focus; **high-contrast has no token**. One stylesheet in the fleet — `themes/base/resources/css/app.css` — addresses `forced-colors`, and the same single file addresses `prefers-reduced-motion` | 4 of 4 themes, inherited from `base` | unenforced | tokens in `base`; the three children inherit |
+| **100 lines exceed the 120-character limit**, across 50 files. `PSR.md` calls it a **soft** limit — "split long code where clarity improves" — so this is a reading of intent rather than a breach, and no fixer enforces it | 50 of 216 source files | style only | 100 line splits, judged individually; Pint has no line-length fixer |
+
+## Prose (fleet) class — conformance
+
+| Rule | Evidence |
+| --- | --- |
+| Optional infrastructure bound at composition time (`ADOPTION.md` rule 2) | the analytics adapters are the pattern done correctly — a guarded `bound()` check means a missing capability omits its behaviour rather than throwing. The finding above is that this is undocumented, not that it is wrong |
+| Controllers are thin (`CONTROLLERS.md`) | the whole fleet ships **2 controllers**: `SearchController` with 3 public methods, `ReadinessController` with 1 |
+| Traits are rare and justified (`CONCERNS.md`) | **2 traits fleet-wide** — `Searchable`, a published extension point, and `PasswordValidationRules`, a Fortify convention. The standard's "show at least two real owners" is a bar for adding one, and the fleet has barely added any |
+| One documented cascade-layer order (`THEMES.md` §9) | **4 of 4** themes use `@layer` |
+| Consent before analytics scripts (`THEMES.md` §16) | 13 references to consent across the analytics modules |
+| Create only the test suites the repository needs (`TESTING.md` §4) | the fleet uses `Feature` (9), `Unit` (8) and `Fixtures` (4) of the nine suites the standard lists. The standard says "Create only suites the repository needs"; the shared boundary suite covers the rest, per `CONFORMANCE.md` §3.7 |
+
 ## Where the ranks strained, and what was decided
 
 **Every CI finding ranks *unenforced*.** That is structural, not a defect: the class is defined as
@@ -202,6 +227,5 @@ realized consequence — and left 22 findings unchanged.
 
 ## Not yet audited
 
-Arch (11 clusters), Larastan (6), Pint (3) and Prose (fleet) (38). Each is its own ticket under the
-map. Until those land, a standard marked *no Boundary rules* or *no CI rules* above has been
+Arch (11 clusters), Larastan (6) and Pint (3). Each is its own ticket under the map. Until those land, a standard marked *no Boundary rules* or *no CI rules* above has been
 **classified, not audited** — its rules live in a class this document has not reached.

--- a/docs/CODE-CONFORMANCE.md
+++ b/docs/CODE-CONFORMANCE.md
@@ -26,6 +26,17 @@ There is no *breaks a test* rank. The fleet's CI is green, so anything that brok
 already be red and would be a bug report rather than an audit finding. Settled in
 [Define what a finding is, and how findings rank](https://github.com/liberusoftware/boilerplate-laravel/issues/645).
 
+**⚠ security** is a flag, not a rank. The four ranks describe *realized* consequence — what is
+broken, what is untrue, what is ungated, what is cosmetic. A supply-chain exposure has no realized
+consequence; it is risk, and *unenforced* is already the risk bucket. The flag records impact within
+that bucket without asserting a false ordering between "arbitrary code execution someday" and "a
+consumer breaks today". Settled in
+[Does the ranking need a security rank](https://github.com/liberusoftware/boilerplate-laravel/issues/651).
+
+**Rank compares across the document; cost separates within a class.** A class whose rules share one
+failure mode will legitimately show one rank — see the CI class below, where all 17 findings are
+*unenforced* and the cost column runs from "2 lines" to "unknown".
+
 ## How the audit is sliced
 
 Not per standard. Every rule in the corpus was classified by the **mechanism that could catch it**,
@@ -130,13 +141,13 @@ then static analysis — were both silence mistaken for health.
 ## CI class — findings
 
 Rules that are mechanically decidable but by a workflow step rather than by Pint or Larastan. All 17
-findings rank **unenforced**, and that is not a coincidence — see *What the ranks did not survive*
-below.
+findings rank **unenforced**, and that is not a coincidence — see *Where the ranks strained* below.
+Two carry the **⚠ security** flag.
 
 | Rule | Population | Rank | Cost |
 | --- | --- | --- | --- |
-| **Third-party actions are not pinned to full-length commit SHAs.** `CI.md`, *Workflow security*: "Pin third-party actions to full-length commit SHAs". Every reference is a mutable tag — `actions/checkout@v5`, `shivammathur/setup-php@v2`, `actions/cache@v4`, `codecov/codecov-action@v5`, four `docker/*` actions | **21 references** across 4 host workflows and 3 reusable workflows | unenforced | 7 files, one PR each; then a renewal process, because pinned SHAs need updating |
-| **All 44 package callers pin the reusable workflow to `@main`.** A push to `liberusoftware/.github` changes every repository's CI instantly, with no staging. Demonstrated in this effort: adding a `--config` flag pointing at a not-yet-tagged file would have failed all 44 builds, and needed a guard commit rather than a rollback | 44 of 44 | unenforced | 44 files to pin, or a release process for the reusable workflows |
+| **Third-party actions are not pinned to full-length commit SHAs.** `CI.md`, *Workflow security*: "Pin third-party actions to full-length commit SHAs". Every reference is a mutable tag — `actions/checkout@v5`, `shivammathur/setup-php@v2`, `actions/cache@v4`, `codecov/codecov-action@v5`, four `docker/*` actions | **21 references** across 4 host workflows and 3 reusable workflows | unenforced **⚠ security** | 7 files, one PR each; then a renewal process, because pinned SHAs need updating |
+| **All 44 package callers pin the reusable workflow to `@main`.** A push to `liberusoftware/.github` changes every repository's CI instantly, with no staging. Demonstrated in this effort: adding a `--config` flag pointing at a not-yet-tagged file would have failed all 44 builds, and needed a guard commit rather than a rollback | 44 of 44 | unenforced **⚠ security** | 44 files to pin, or a release process for the reusable workflows |
 | **`composer validate` and `composer audit` run only at tag time for packages.** They are in `package-install.yml`, which triggers on tags and `workflow_dispatch`. `CI.md` requires them on every pull request and every push to `main` | 44 of 44 packages | unenforced | one step each in `package-tests.yml` |
 | **Host `install.yml` declares no `permissions:` block.** `CI.md`: least-privilege, "normally starting with `contents: read`". The other three host workflows and all three reusable workflows declare one | 1 of 4 host workflows | unenforced | 2 lines |
 | **No secret scanning anywhere.** `CI.md` requires "dependency, secret, container, and supported security scans". Dependency scanning exists — `composer audit --locked` in the host, `composer audit` at package release. The other two do not | host + 44 packages | unenforced | one workflow, fleet-wide via the reusable caller |
@@ -168,25 +179,26 @@ below.
 | SFC/MFC filenames free of the bolt emoji (`LIVEWIRE.md` §6) | **0** — vacuous, the fleet ships no SFC/MFC |
 | Islands not placed inside loops or conditionals (`LIVEWIRE.md` §17) | **0 islands** — vacuous |
 
-## What the ranks did not survive
+## Where the ranks strained, and what was decided
 
-**Every CI finding ranks *unenforced*, and the rank therefore carries no information here.** That is
-structural: this class is defined as *decidable by a workflow step*, so its failure mode is always
-"no workflow step does it", which is the definition of *unenforced*. The rank separates findings
-usefully in the Boundary class — 1 consumer, 2 promise, 3 unenforced, 1 style — and degenerates in
-this one.
+**Every CI finding ranks *unenforced*.** That is structural, not a defect: the class is defined as
+*decidable by a workflow step*, so its only failure mode is "no workflow step does it" — which is the
+definition of *unenforced*. The same four ranks separate the Boundary class usefully (1 consumer,
+2 promise, 3 unenforced, 1 style).
 
-Two rows are also ranked lower than they deserve, both flagged when the ranks were settled:
+The obvious remedy was tested and rejected on the evidence. Splitting *unenforced* into **violated**
+(the rule is broken now) and **unguarded** (a check is absent for a property that may well be fine)
+partitions the CI class **16 to 1** — nearly every CI rule is "have this check", so not having it is
+both at once. It adds a distinction the findings do not support.
 
-- **Unpinned actions** is a live supply-chain exposure — a moved tag executes arbitrary code in CI —
-  with no consumer-visible symptom and nothing false claimed. *Unenforced* undersells it.
-- **`@main` on the reusable workflow** has the same shape, and this effort produced the near-miss
-  that proves it.
+What separates a uniform-rank class is the **cost** column, which already runs from `2 lines` to
+`unknown`. Rank compares across the document; cost compares within a class.
 
-Two candidates were named when the ranks were defined as the trigger for adding a **security** rank.
-This is the second, and it is the same shape as the first. The recommendation is on the record here
-rather than acted on, because ranking is a settled decision and re-opening it is the map's call, not
-the audit's.
+**Two rows carry ⚠ security.** Unpinned actions and the `@main` reusable-workflow reference are both
+live supply-chain exposure with no consumer-visible symptom and nothing false claimed. When the ranks
+were settled, the first was named as the precedent to point at if a second of the same shape
+appeared; the CI audit produced it. The flag, rather than a fifth rank, keeps the rank axis meaning
+realized consequence — and left 22 findings unchanged.
 
 ## Not yet audited
 

--- a/modules/activity-comments/.github/workflows/tests.yml
+++ b/modules/activity-comments/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 33

--- a/modules/activity-comments/composer.json
+++ b/modules/activity-comments/composer.json
@@ -19,7 +19,7 @@
       "name": "activity-comments"
     }
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\ActivityComments\\Tests\\": "tests/"

--- a/modules/activity-comments/module.json
+++ b/modules/activity-comments/module.json
@@ -3,7 +3,7 @@
     "name": "activity-comments",
     "display_name": "Activity and Comments",
     "description": "Generic authorized activity timelines, mentions, subscriptions, internal comments, attachments, and visibility controls.",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "category": "foundation",
     "provider": "Liberu\\Foundation\\ActivityComments\\ActivityCommentsServiceProvider",
     "requires": {

--- a/modules/analytics-core/.github/workflows/tests.yml
+++ b/modules/analytics-core/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 88

--- a/modules/analytics-core/composer.json
+++ b/modules/analytics-core/composer.json
@@ -20,7 +20,7 @@
       "name": "analytics-core"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Analytics\\Core\\Tests\\": "tests/"

--- a/modules/analytics-core/module.json
+++ b/modules/analytics-core/module.json
@@ -3,7 +3,7 @@
   "name": "analytics-core",
   "display_name": "Analytics Core",
   "description": "Versioned event envelopes, consent, mapping, minimization, routing, deduplication, queues, redaction, and delivery audit.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "capability",
   "provider": "Liberu\\Analytics\\Core\\AnalyticsServiceProvider",
   "requires": {

--- a/modules/analytics-google/.github/workflows/tests.yml
+++ b/modules/analytics-google/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 87

--- a/modules/analytics-google/composer.json
+++ b/modules/analytics-google/composer.json
@@ -19,7 +19,7 @@
       "name": "analytics-google"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Analytics\\Google\\Tests\\": "tests/"

--- a/modules/analytics-google/module.json
+++ b/modules/analytics-google/module.json
@@ -3,7 +3,7 @@
   "name": "analytics-google",
   "display_name": "Google Analytics",
   "description": "Consent-aware Google event mapping, property/stream configuration, validation, ecommerce parameters, and diagnostics.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "adapter",
   "provider": "Liberu\\Analytics\\Google\\AnalyticsGoogleServiceProvider",
   "requires": {

--- a/modules/analytics-meta/.github/workflows/tests.yml
+++ b/modules/analytics-meta/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 87

--- a/modules/analytics-meta/composer.json
+++ b/modules/analytics-meta/composer.json
@@ -19,7 +19,7 @@
       "name": "analytics-meta"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Analytics\\Meta\\Tests\\": "tests/"

--- a/modules/analytics-meta/module.json
+++ b/modules/analytics-meta/module.json
@@ -3,7 +3,7 @@
   "name": "analytics-meta",
   "display_name": "Meta Server-Side Tracking",
   "description": "Consent-aware Meta event mapping, browser/server deduplication, normalization/hashing, protected configuration, and diagnostics.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "adapter",
   "provider": "Liberu\\Analytics\\Meta\\AnalyticsMetaServiceProvider",
   "requires": {

--- a/modules/api-access/.github/workflows/tests.yml
+++ b/modules/api-access/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 11

--- a/modules/api-access/composer.json
+++ b/modules/api-access/composer.json
@@ -20,7 +20,7 @@
       "name": "api-access"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\ApiAccess\\Tests\\": "tests/"

--- a/modules/api-access/module.json
+++ b/modules/api-access/module.json
@@ -3,7 +3,7 @@
   "name": "api-access",
   "display_name": "API Access",
   "description": "Token and service-identity policy, scopes, versions, rate limits, idempotency, expiry, and revocation.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\ApiAccess\\ApiAccessServiceProvider",
   "requires": {

--- a/modules/application/.github/workflows/tests.yml
+++ b/modules/application/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 26

--- a/modules/application/composer.json
+++ b/modules/application/composer.json
@@ -19,7 +19,7 @@
       "name": "application"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\ApplicationCore\\Tests\\": "tests/"

--- a/modules/application/module.json
+++ b/modules/application/module.json
@@ -3,7 +3,7 @@
   "name": "application",
   "display_name": "Application Core",
   "description": "Application metadata, health/readiness, secure response defaults, clocks, and shared identifiers.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\ApplicationCore\\ApplicationCoreServiceProvider",
   "requires": {

--- a/modules/audit/.github/workflows/tests.yml
+++ b/modules/audit/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 12

--- a/modules/audit/composer.json
+++ b/modules/audit/composer.json
@@ -19,7 +19,7 @@
       "name": "audit"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Audit\\Tests\\": "tests/"

--- a/modules/audit/module.json
+++ b/modules/audit/module.json
@@ -3,7 +3,7 @@
   "name": "audit",
   "display_name": "Audit",
   "description": "Actor, tenant, request and correlation-aware material-change audit with export and retention boundaries.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Audit\\AuditServiceProvider",
   "requires": {

--- a/modules/currency-context/.github/workflows/tests.yml
+++ b/modules/currency-context/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 41

--- a/modules/currency-context/composer.json
+++ b/modules/currency-context/composer.json
@@ -19,7 +19,7 @@
       "name": "currency-context"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Currency\\Tests\\": "tests/"

--- a/modules/currency-context/module.json
+++ b/modules/currency-context/module.json
@@ -3,7 +3,7 @@
   "name": "currency-context",
   "display_name": "Currency Context",
   "description": "ISO metadata, precise money values, currency roles, formatting, and effective-dated exchange-rate contracts.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Currency\\CurrencyServiceProvider",
   "requires": {

--- a/modules/developer-experience/.github/workflows/tests.yml
+++ b/modules/developer-experience/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 10

--- a/modules/developer-experience/composer.json
+++ b/modules/developer-experience/composer.json
@@ -19,7 +19,7 @@
       "name": "developer-experience"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\DeveloperExperience\\Tests\\": "tests/"

--- a/modules/developer-experience/module.json
+++ b/modules/developer-experience/module.json
@@ -3,7 +3,7 @@
   "name": "developer-experience",
   "display_name": "Developer Experience",
   "description": "Local environment, fixtures, quality scripts, CI, architecture checks, documentation, and upgrade diagnostics.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\DeveloperExperience\\DeveloperExperienceServiceProvider",
   "requires": {

--- a/modules/feature-flags/.github/workflows/tests.yml
+++ b/modules/feature-flags/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 3
       coverage-threshold: 7

--- a/modules/feature-flags/composer.json
+++ b/modules/feature-flags/composer.json
@@ -19,7 +19,7 @@
       "name": "feature-flags"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\FeatureFlags\\Tests\\": "tests/"

--- a/modules/feature-flags/module.json
+++ b/modules/feature-flags/module.json
@@ -3,7 +3,7 @@
   "name": "feature-flags",
   "display_name": "Feature Flags",
   "description": "Typed flags, environment/tenant/actor targeting, stable rollout, ownership, expiry, and telemetry boundaries.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\FeatureFlags\\FeatureFlagsServiceProvider",
   "requires": {

--- a/modules/files-media/.github/workflows/tests.yml
+++ b/modules/files-media/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 28

--- a/modules/files-media/composer.json
+++ b/modules/files-media/composer.json
@@ -19,7 +19,7 @@
       "name": "files-media"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Files\\Tests\\": "tests/"

--- a/modules/files-media/module.json
+++ b/modules/files-media/module.json
@@ -3,7 +3,7 @@
   "name": "files-media",
   "display_name": "Files and Media",
   "description": "Secure storage contracts, uploads, validation, scanning, metadata, transformations, access, and retention.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Files\\FilesMediaServiceProvider",
   "requires": {

--- a/modules/identity-core-filament/.github/workflows/tests.yml
+++ b/modules/identity-core-filament/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 59

--- a/modules/identity-core-filament/composer.json
+++ b/modules/identity-core-filament/composer.json
@@ -18,7 +18,7 @@
       "name": "identity-core-filament"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\IdentityFilament\\Tests\\": "tests/"

--- a/modules/identity-core-filament/module.json
+++ b/modules/identity-core-filament/module.json
@@ -3,7 +3,7 @@
     "name": "identity-core-filament",
     "display_name": "Identity Administration",
     "description": "Optional Filament user and role administration surface.",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "category": "presentation",
     "provider": "Liberu\\Foundation\\IdentityFilament\\IdentityFilamentServiceProvider",
     "requires": {

--- a/modules/identity-core/.github/workflows/tests.yml
+++ b/modules/identity-core/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 8
       coverage-threshold: 35

--- a/modules/identity-core/composer.json
+++ b/modules/identity-core/composer.json
@@ -18,7 +18,7 @@
       "name": "identity-core"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Identity\\Tests\\": "tests/"

--- a/modules/identity-core/module.json
+++ b/modules/identity-core/module.json
@@ -3,7 +3,7 @@
   "name": "identity-core",
   "display_name": "Identity",
   "description": "Provider-neutral authentication policy, identifier normalization, and security events.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Identity\\IdentityServiceProvider",
   "requires": {

--- a/modules/identity-socialstream/.github/workflows/tests.yml
+++ b/modules/identity-socialstream/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 10

--- a/modules/identity-socialstream/composer.json
+++ b/modules/identity-socialstream/composer.json
@@ -22,7 +22,7 @@
       "name": "identity-socialstream"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Identity\\Socialstream\\Tests\\": "tests/"

--- a/modules/identity-socialstream/module.json
+++ b/modules/identity-socialstream/module.json
@@ -3,7 +3,7 @@
   "name": "identity-socialstream",
   "display_name": "Social Identity",
   "description": "Social provider redirects, callbacks, identity linking, protected credentials, and account synchronization.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "adapter",
   "provider": "Liberu\\Foundation\\Identity\\Socialstream\\Providers\\SocialstreamServiceProvider",
   "requires": {

--- a/modules/import-export/.github/workflows/tests.yml
+++ b/modules/import-export/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 7

--- a/modules/import-export/composer.json
+++ b/modules/import-export/composer.json
@@ -19,7 +19,7 @@
       "name": "import-export"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\ImportExport\\Tests\\": "tests/"

--- a/modules/import-export/module.json
+++ b/modules/import-export/module.json
@@ -3,7 +3,7 @@
   "name": "import-export",
   "display_name": "Import and Export",
   "description": "Schemas, mapping, dry runs, validation, queued execution, progress, error reports, authorization, and retention.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\ImportExport\\ImportExportServiceProvider",
   "requires": {

--- a/modules/integrations/.github/workflows/tests.yml
+++ b/modules/integrations/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 22

--- a/modules/integrations/composer.json
+++ b/modules/integrations/composer.json
@@ -19,7 +19,7 @@
       "name": "integrations"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Integrations\\Tests\\": "tests/"

--- a/modules/integrations/module.json
+++ b/modules/integrations/module.json
@@ -3,7 +3,7 @@
   "name": "integrations",
   "display_name": "Integrations",
   "description": "Provider credentials, adapter capabilities, OAuth boundaries, rotation, connection tests, sync, and reconciliation.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Integrations\\IntegrationsServiceProvider",
   "requires": {

--- a/modules/jetstream-bridge/.github/workflows/tests.yml
+++ b/modules/jetstream-bridge/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 13

--- a/modules/jetstream-bridge/composer.json
+++ b/modules/jetstream-bridge/composer.json
@@ -21,7 +21,7 @@
       "name": "jetstream-bridge"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\JetstreamBridge\\Tests\\": "tests/"

--- a/modules/jetstream-bridge/module.json
+++ b/modules/jetstream-bridge/module.json
@@ -3,7 +3,7 @@
   "name": "jetstream-bridge",
   "display_name": "Jetstream Bridge",
   "description": "Fortify and Jetstream-compatible registration, profile, password, team, and account-deletion actions.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\JetstreamBridge\\Providers\\FortifyServiceProvider",
   "requires": {

--- a/modules/localization-core-livewire/.github/workflows/tests.yml
+++ b/modules/localization-core-livewire/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 4
       coverage-threshold: 100

--- a/modules/localization-core-livewire/composer.json
+++ b/modules/localization-core-livewire/composer.json
@@ -18,7 +18,7 @@
       "name": "localization-core-livewire"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\LocalizationLivewire\\Tests\\": "tests/"

--- a/modules/localization-core-livewire/module.json
+++ b/modules/localization-core-livewire/module.json
@@ -3,7 +3,7 @@
   "name": "localization-core-livewire",
   "display_name": "Localization Livewire",
   "description": "Interactive locale selection for Livewire applications.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "presentation",
   "provider": "Liberu\\Foundation\\LocalizationLivewire\\LocalizationLivewireServiceProvider",
   "requires": {

--- a/modules/localization-core/.github/workflows/tests.yml
+++ b/modules/localization-core/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 80

--- a/modules/localization-core/composer.json
+++ b/modules/localization-core/composer.json
@@ -21,7 +21,7 @@
       "name": "localization-core"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Localization\\Tests\\": "tests/"

--- a/modules/localization-core/module.json
+++ b/modules/localization-core/module.json
@@ -3,7 +3,7 @@
   "name": "localization-core",
   "display_name": "Localization",
   "description": "Locale negotiation, user preference, translations, timezone context, and RTL hooks.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Localization\\LocalizationServiceProvider",
   "requires": {

--- a/modules/localization-mymemory/.github/workflows/tests.yml
+++ b/modules/localization-mymemory/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 94

--- a/modules/localization-mymemory/composer.json
+++ b/modules/localization-mymemory/composer.json
@@ -19,7 +19,7 @@
       "name": "localization-mymemory"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Localization\\MyMemory\\Tests\\": "tests/"

--- a/modules/localization-mymemory/module.json
+++ b/modules/localization-mymemory/module.json
@@ -3,7 +3,7 @@
   "name": "localization-mymemory",
   "display_name": "MyMemory Translation",
   "description": "Optional cached MyMemory machine-translation provider adapter.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "adapter",
   "provider": "Liberu\\Foundation\\Localization\\MyMemory\\MyMemoryServiceProvider",
   "requires": {

--- a/modules/module-manager-filament/.github/workflows/tests.yml
+++ b/modules/module-manager-filament/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 12

--- a/modules/module-manager-filament/composer.json
+++ b/modules/module-manager-filament/composer.json
@@ -19,7 +19,7 @@
       "name": "module-manager-filament"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\ModuleManagerFilament\\Tests\\": "tests/"

--- a/modules/module-manager-filament/module.json
+++ b/modules/module-manager-filament/module.json
@@ -3,7 +3,7 @@
   "name": "module-manager-filament",
   "display_name": "Module Manager Administration",
   "description": "Authorized installed-module diagnostics for the admin panel.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "presentation",
   "provider": "Liberu\\Foundation\\ModuleManagerFilament\\ModuleManagerFilamentServiceProvider",
   "requires": {

--- a/modules/module-manager/.github/workflows/tests.yml
+++ b/modules/module-manager/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 80

--- a/modules/module-manager/composer.json
+++ b/modules/module-manager/composer.json
@@ -19,7 +19,7 @@
       "name": "module-manager"
     }
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\ModuleManager\\Tests\\": "tests/"

--- a/modules/module-manager/module.json
+++ b/modules/module-manager/module.json
@@ -3,7 +3,7 @@
     "name": "module-manager",
     "display_name": "Module Manager",
     "description": "Manifest discovery, dependency resolution, deployment enablement, registry caching, and diagnostics.",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "category": "foundation",
     "provider": "Liberu\\Foundation\\ModuleManager\\ModuleManagerServiceProvider",
     "requires": {

--- a/modules/notifications/.github/workflows/tests.yml
+++ b/modules/notifications/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 11

--- a/modules/notifications/composer.json
+++ b/modules/notifications/composer.json
@@ -19,7 +19,7 @@
       "name": "notifications"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Notifications\\Tests\\": "tests/"

--- a/modules/notifications/module.json
+++ b/modules/notifications/module.json
@@ -3,7 +3,7 @@
   "name": "notifications",
   "display_name": "Notifications",
   "description": "Localized templates, channel preferences, inbox state, retries, delivery status, and quiet hours.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Notifications\\NotificationsServiceProvider",
   "requires": {

--- a/modules/observability/.github/workflows/tests.yml
+++ b/modules/observability/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 44

--- a/modules/observability/composer.json
+++ b/modules/observability/composer.json
@@ -20,7 +20,7 @@
       "name": "observability"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Observability\\Tests\\": "tests/"

--- a/modules/observability/module.json
+++ b/modules/observability/module.json
@@ -3,7 +3,7 @@
   "name": "observability",
   "display_name": "Observability",
   "description": "Structured diagnostics, exception/job/request monitoring, metrics storage, redaction, and authorized dashboards.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Observability\\ObservabilityServiceProvider",
   "requires": {

--- a/modules/organizations-teams-filament/.github/workflows/tests.yml
+++ b/modules/organizations-teams-filament/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 67

--- a/modules/organizations-teams-filament/composer.json
+++ b/modules/organizations-teams-filament/composer.json
@@ -18,7 +18,7 @@
       "name": "organizations-teams-filament"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\OrganizationsFilament\\Tests\\": "tests/"

--- a/modules/organizations-teams-filament/module.json
+++ b/modules/organizations-teams-filament/module.json
@@ -3,7 +3,7 @@
     "name": "organizations-teams-filament",
     "display_name": "Organizations Administration",
     "description": "Optional Filament team administration resources.",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "category": "presentation",
     "provider": "Liberu\\Foundation\\OrganizationsFilament\\OrganizationsFilamentServiceProvider",
     "requires": {

--- a/modules/organizations-teams/.github/workflows/tests.yml
+++ b/modules/organizations-teams/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 10

--- a/modules/organizations-teams/composer.json
+++ b/modules/organizations-teams/composer.json
@@ -20,7 +20,7 @@
       "name": "organizations-teams"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Organizations\\Tests\\": "tests/"

--- a/modules/organizations-teams/module.json
+++ b/modules/organizations-teams/module.json
@@ -3,7 +3,7 @@
   "name": "organizations-teams",
   "display_name": "Organizations and Teams",
   "description": "Teams, memberships, invitations, ownership, switching, and current-context boundaries.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Organizations\\OrganizationsServiceProvider",
   "requires": {

--- a/modules/profiles/.github/workflows/tests.yml
+++ b/modules/profiles/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 11

--- a/modules/profiles/composer.json
+++ b/modules/profiles/composer.json
@@ -19,7 +19,7 @@
       "name": "profiles"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Profiles\\Tests\\": "tests/"

--- a/modules/profiles/module.json
+++ b/modules/profiles/module.json
@@ -3,7 +3,7 @@
   "name": "profiles",
   "display_name": "Profiles",
   "description": "Controlled names, locale, timezone, avatar, contact, and theme preferences.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Profiles\\ProfilesServiceProvider",
   "requires": {

--- a/modules/roles-permissions-filament/.github/workflows/tests.yml
+++ b/modules/roles-permissions-filament/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 100

--- a/modules/roles-permissions-filament/composer.json
+++ b/modules/roles-permissions-filament/composer.json
@@ -19,7 +19,7 @@
       "name": "roles-permissions-filament"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\RolesPermissionsFilament\\Tests\\": "tests/"

--- a/modules/roles-permissions-filament/module.json
+++ b/modules/roles-permissions-filament/module.json
@@ -3,7 +3,7 @@
     "name": "roles-permissions-filament",
     "display_name": "Roles and Permissions Filament",
     "description": "Filament role and permission management through the roles and permissions capability.",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "category": "presentation",
     "provider": "Liberu\\Foundation\\RolesPermissionsFilament\\RolesPermissionsFilamentServiceProvider",
     "requires": {

--- a/modules/roles-permissions/.github/workflows/tests.yml
+++ b/modules/roles-permissions/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 12

--- a/modules/roles-permissions/composer.json
+++ b/modules/roles-permissions/composer.json
@@ -19,7 +19,7 @@
       "name": "roles-permissions"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\RolesPermissions\\Tests\\": "tests/"

--- a/modules/roles-permissions/module.json
+++ b/modules/roles-permissions/module.json
@@ -3,7 +3,7 @@
   "name": "roles-permissions",
   "display_name": "Roles and Permissions",
   "description": "Contextual role assignments, module-owned permissions, policies, and cache invalidation.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\RolesPermissions\\RolesPermissionsServiceProvider",
   "requires": {

--- a/modules/scheduler-queues/.github/workflows/tests.yml
+++ b/modules/scheduler-queues/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 33

--- a/modules/scheduler-queues/composer.json
+++ b/modules/scheduler-queues/composer.json
@@ -19,7 +19,7 @@
       "name": "scheduler-queues"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\SchedulerQueues\\Tests\\": "tests/"

--- a/modules/scheduler-queues/module.json
+++ b/modules/scheduler-queues/module.json
@@ -3,7 +3,7 @@
   "name": "scheduler-queues",
   "display_name": "Scheduler and Queues",
   "description": "Unique/idempotent job policy, schedules, locks, retries, failures, monitoring, and graceful deployment conventions.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\SchedulerQueues\\SchedulerQueuesServiceProvider",
   "requires": {

--- a/modules/search-api/.github/workflows/tests.yml
+++ b/modules/search-api/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 3

--- a/modules/search-api/composer.json
+++ b/modules/search-api/composer.json
@@ -19,7 +19,7 @@
       "name": "search-api"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\SearchApi\\Tests\\": "tests/"

--- a/modules/search-api/module.json
+++ b/modules/search-api/module.json
@@ -3,7 +3,7 @@
   "name": "search-api",
   "display_name": "Search API",
   "description": "Authenticated, rate-limited HTTP endpoints for Search.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "presentation",
   "provider": "Liberu\\Foundation\\SearchApi\\SearchApiServiceProvider",
   "requires": {

--- a/modules/search/.github/workflows/tests.yml
+++ b/modules/search/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 70

--- a/modules/search/composer.json
+++ b/modules/search/composer.json
@@ -20,7 +20,7 @@
       "name": "search"
     }
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Search\\Tests\\": "tests/"

--- a/modules/search/module.json
+++ b/modules/search/module.json
@@ -3,7 +3,7 @@
     "name": "search",
     "display_name": "Search",
     "description": "Authorized search queries, filters, pagination, and replaceable model configuration.",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "category": "foundation",
     "provider": "Liberu\\Foundation\\Search\\SearchServiceProvider",
     "requires": {

--- a/modules/sessions-devices-filament/.github/workflows/tests.yml
+++ b/modules/sessions-devices-filament/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 11

--- a/modules/sessions-devices-filament/composer.json
+++ b/modules/sessions-devices-filament/composer.json
@@ -18,7 +18,7 @@
       "name": "sessions-devices-filament"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\SessionsDevicesFilament\\Tests\\": "tests/"

--- a/modules/sessions-devices-filament/module.json
+++ b/modules/sessions-devices-filament/module.json
@@ -3,7 +3,7 @@
   "name": "sessions-devices-filament",
   "display_name": "Sessions and Devices Administration",
   "description": "Accessible account security and preferences surface for the app panel.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "presentation",
   "provider": "Liberu\\Foundation\\SessionsDevicesFilament\\SessionsDevicesFilamentServiceProvider",
   "requires": {

--- a/modules/sessions-devices/.github/workflows/tests.yml
+++ b/modules/sessions-devices/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 2
       coverage-threshold: 9

--- a/modules/sessions-devices/composer.json
+++ b/modules/sessions-devices/composer.json
@@ -19,7 +19,7 @@
       "name": "sessions-devices"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Sessions\\Tests\\": "tests/"

--- a/modules/sessions-devices/module.json
+++ b/modules/sessions-devices/module.json
@@ -3,7 +3,7 @@
   "name": "sessions-devices",
   "display_name": "Sessions and Devices",
   "description": "Privacy-conscious active-session inventory, current-session protection, and revocation.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Sessions\\SessionsDevicesServiceProvider",
   "requires": {

--- a/modules/settings-filament/.github/workflows/tests.yml
+++ b/modules/settings-filament/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 9
       coverage-threshold: 98

--- a/modules/settings-filament/composer.json
+++ b/modules/settings-filament/composer.json
@@ -20,7 +20,7 @@
       "name": "settings-filament"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\SettingsFilament\\Tests\\": "tests/"

--- a/modules/settings-filament/module.json
+++ b/modules/settings-filament/module.json
@@ -3,7 +3,7 @@
     "name": "settings-filament",
     "display_name": "Settings Administration",
     "description": "Optional Filament settings administration surface.",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "category": "presentation",
     "provider": "Liberu\\Foundation\\SettingsFilament\\SettingsFilamentServiceProvider",
     "requires": {

--- a/modules/settings/.github/workflows/tests.yml
+++ b/modules/settings/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 5
       coverage-threshold: 20

--- a/modules/settings/composer.json
+++ b/modules/settings/composer.json
@@ -18,7 +18,7 @@
       "name": "settings"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Settings\\Tests\\": "tests/"

--- a/modules/settings/module.json
+++ b/modules/settings/module.json
@@ -3,7 +3,7 @@
   "name": "settings",
   "display_name": "Settings",
   "description": "Typed application, organization, team/site, and user settings with validation and deterministic cache invalidation.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Settings\\SettingsServiceProvider",
   "requires": {

--- a/modules/theme-support-livewire/.github/workflows/tests.yml
+++ b/modules/theme-support-livewire/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 4
       coverage-threshold: 100

--- a/modules/theme-support-livewire/composer.json
+++ b/modules/theme-support-livewire/composer.json
@@ -18,7 +18,7 @@
       "name": "theme-support-livewire"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\ThemeSupportLivewire\\Tests\\": "tests/"

--- a/modules/theme-support-livewire/module.json
+++ b/modules/theme-support-livewire/module.json
@@ -3,7 +3,7 @@
   "name": "theme-support-livewire",
   "display_name": "Theme Support Livewire",
   "description": "Interactive theme selection for Livewire applications.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "presentation",
   "provider": "Liberu\\Foundation\\ThemeSupportLivewire\\ThemeSupportLivewireServiceProvider",
   "requires": {

--- a/modules/theme-support/.github/workflows/tests.yml
+++ b/modules/theme-support/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 1
       coverage-threshold: 74

--- a/modules/theme-support/composer.json
+++ b/modules/theme-support/composer.json
@@ -21,7 +21,7 @@
       "name": "theme-support"
     }
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Theme\\Tests\\": "tests/"

--- a/modules/theme-support/module.json
+++ b/modules/theme-support/module.json
@@ -3,7 +3,7 @@
     "name": "theme-support",
     "display_name": "Theme Support",
     "description": "Theme discovery, view overrides, safe asset directives, preferences, and panel palettes.",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "category": "foundation",
     "provider": "Liberu\\Foundation\\Theme\\Providers\\ThemeServiceProvider",
     "requires": {

--- a/modules/two-factor-authentication/.github/workflows/tests.yml
+++ b/modules/two-factor-authentication/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 2
       coverage-threshold: 12

--- a/modules/two-factor-authentication/composer.json
+++ b/modules/two-factor-authentication/composer.json
@@ -19,7 +19,7 @@
       "name": "two-factor-authentication"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\TwoFactor\\Tests\\": "tests/"

--- a/modules/two-factor-authentication/module.json
+++ b/modules/two-factor-authentication/module.json
@@ -3,7 +3,7 @@
   "name": "two-factor-authentication",
   "display_name": "Two-Factor Authentication",
   "description": "TOTP enforcement, trusted-device policy, and single-use recovery primitives.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\TwoFactor\\TwoFactorServiceProvider",
   "requires": {

--- a/modules/webhooks/.github/workflows/tests.yml
+++ b/modules/webhooks/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 16

--- a/modules/webhooks/composer.json
+++ b/modules/webhooks/composer.json
@@ -19,7 +19,7 @@
       "name": "webhooks"
     }
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "autoload-dev": {
     "psr-4": {
       "Liberu\\Foundation\\Webhooks\\Tests\\": "tests/"

--- a/modules/webhooks/module.json
+++ b/modules/webhooks/module.json
@@ -3,7 +3,7 @@
   "name": "webhooks",
   "display_name": "Webhooks",
   "description": "Endpoint registration, signing, filtering, delivery evidence, backoff, rotation, replay, and logs.",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "category": "foundation",
   "provider": "Liberu\\Foundation\\Webhooks\\WebhooksServiceProvider",
   "requires": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,8 +4,17 @@ includes:
 
 parameters:
 
+    # app/ only. modules/ and themes/ are Composer output — analysing them from
+    # here uses the host's resolution rather than the package's own, and the
+    # package is the only place its source can be analysed against the tree a
+    # consumer actually installs. Each package carries its own measured level in
+    # its tests.yml, as the reusable workflow's phpstan-level input.
     paths:
         - app/
 
-    # Level 10 is the highest level
-    level: 9
+    # Measured, not aspired to. This was 9 while CI ran phpstan never; app/ has
+    # 5 errors at 9, 2 at 6, and none at 5. Level 5 is the first level this code
+    # has ever actually met, and the ratchet is what moves it back up — the same
+    # policy every package is now held to. The five level-9 errors are audit
+    # findings, not a reason to keep a number nothing enforced.
+    level: 5

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,8 @@ genre, repository, component paths, prefixes, and additional Composer packages.
 - `fleet` fans a command across the component repositories once they are the source of truth — `status`, `clone`, `run`, `commit`, and a separate `tag` that only ever acts on an explicit `--only` list. It replaced `publish-components`, which rsynced a monorepo *into* its component repositories — the opposite direction, and meaningless once those repositories are the source.
 - `set-coverage-thresholds` writes each measured figure into that package's `tests.yml`, ratcheting only upward — a package that has lost coverage keeps its threshold and is reported.
 - `measure-coverage` resolves each package from nothing and runs its own suite under pcov, writing `storage/app/coverage.tsv` — the evidence a repository sets its coverage threshold from.
+- `measure-phpstan` finds the highest PHPStan level each package's `src/` passes, by bisection over a standalone resolution, writing `storage/app/phpstan.tsv`. Levels are monotone, so four runs settle it instead of eleven.
+- `set-phpstan-levels` writes each measured level into that package's `tests.yml` as the reusable workflow's `phpstan-level` input, ratcheting only upward and preserving the existing `coverage-threshold`.
 
 All commands are non-interactive and fail on errors. GitHub operations require an
 authenticated `gh` CLI. Packagist operations read `PACKAGIST_USERNAME` and

--- a/scripts/fleet
+++ b/scripts/fleet
@@ -140,8 +140,13 @@ def commit_command(message: str):
             line.split('\t', 1)[1] for line in staged.splitlines()
             if '\t' in line and not line.startswith('D')
         ]
-        if additions:
-            git(target, 'reset', '--quiet', '--', *additions, check=False)
+        # Chunked: a repository with a committed vendor/ tree stages ~10,000
+        # paths, and passing them to one `git reset` exceeds the argv limit —
+        # "[Errno 7] Argument list too long: 'git'". Resetting the NEVER_STAGE
+        # prefixes instead would be shorter but would also unstage deletions,
+        # which is the one thing that must survive.
+        for start in range(0, len(additions), 500):
+            git(target, 'reset', '--quiet', '--', *additions[start:start + 500], check=False)
         pending = git(target, 'diff', '--cached', '--name-only', check=False).stdout.strip()
         if not pending:
             return name, 'nothing to commit'

--- a/scripts/measure-phpstan
+++ b/scripts/measure-phpstan
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Find the highest PHPStan level each package's src/ passes, standalone (step 6).
+
+The sibling of measure-coverage, and for the same reason: a package must be
+analysed against its *own* resolved dependencies, because that is the tree a
+consumer installs. Analysing modules/ from the host would use the host's
+resolution, which sees classes a standalone install does not — and a level
+measured too high becomes a ratchet that reddens CI on the first push.
+
+Bisects rather than walking up from 0: PHPStan levels are monotone, so 4 runs
+find the answer instead of up to 11.
+
+Writes storage/app/phpstan.tsv: package, status, level. Merges rather than
+overwrites, so measuring a subset does not discard a full sweep's results.
+
+Usage: measure-phpstan [--fresh] [--max LEVEL] [PATH ...]
+"""
+import argparse
+import concurrent.futures
+import os
+import pathlib
+import subprocess
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+OUT = ROOT / 'storage/app/phpstan.tsv'
+CONFIG = 'vendor/liberusoftware/package-testbench/phpstan.neon'
+
+
+def run(cmd: list[str], cwd: pathlib.Path, timeout: int) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True, timeout=timeout,
+        env={**os.environ, 'COMPOSER_NO_INTERACTION': '1'},
+    )
+
+
+def passes(pkg: pathlib.Path, level: int) -> bool:
+    result = run(['vendor/bin/phpstan', 'analyse', '-c', CONFIG,
+                  '-l', str(level), '--no-progress', '--error-format=raw', 'src'], pkg, 900)
+    return result.returncode == 0
+
+
+def measure(pkg: pathlib.Path, fresh: bool, ceiling: int) -> tuple[str, str, str]:
+    if fresh or not (pkg / 'vendor').is_dir():
+        install = run(['composer', 'update', '--prefer-dist', '--no-progress'], pkg, 900)
+        if install.returncode != 0:
+            tail = (install.stderr or install.stdout).strip().splitlines()
+            return pkg.name, 'install-failed', tail[-1][:160] if tail else ''
+
+    if not (pkg / CONFIG).is_file():
+        return pkg.name, 'no-config', 'package-testbench does not ship phpstan.neon at this version'
+
+    # Level 0 is the floor. A package failing it has an error no level relaxes —
+    # an unresolvable class, usually — and no threshold is honest until it is fixed.
+    if not passes(pkg, 0):
+        return pkg.name, 'fails-level-0', ''
+
+    low, high = 0, ceiling
+    while low < high:
+        mid = (low + high + 1) // 2
+        if passes(pkg, mid):
+            low = mid
+        else:
+            high = mid - 1
+    return pkg.name, 'ok', str(low)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog='measure-phpstan', description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('paths', nargs='*')
+    parser.add_argument('--fresh', action='store_true', help='reinstall even when vendor/ exists')
+    parser.add_argument('--max', type=int, default=10, dest='ceiling', help='highest level to try (default 10)')
+    args = parser.parse_args()
+
+    if args.paths:
+        packages = [pathlib.Path(p).resolve() for p in args.paths]
+    else:
+        packages = sorted(
+            pkg for base in ('modules', 'themes')
+            for pkg in (ROOT / base).iterdir() if pkg.is_dir()
+        )
+
+    OUT.parent.mkdir(parents=True, exist_ok=True)
+    rows = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as pool:
+        futures = {pool.submit(measure, pkg, args.fresh, args.ceiling): pkg for pkg in packages}
+        for future in concurrent.futures.as_completed(futures):
+            pkg = futures[future]
+            try:
+                row = future.result()
+            except subprocess.TimeoutExpired:
+                row = (pkg.name, 'timeout', '')
+            rows.append(row)
+            print(f'{row[0]:<34}{row[1]:<16}{row[2]}', flush=True)
+
+    existing = {}
+    if OUT.is_file():
+        for line in OUT.read_text().splitlines():
+            if line.strip():
+                fields = line.split('\t')
+                existing[fields[0]] = fields
+    for row in rows:
+        existing[row[0]] = list(row)
+
+    merged = sorted(existing.values())
+    OUT.write_text('\n'.join('\t'.join(r) for r in merged) + '\n')
+    print(f'\nwrote {OUT} ({len(rows)} measured, {len(merged)} total)')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/scripts/measure-phpstan
+++ b/scripts/measure-phpstan
@@ -35,8 +35,12 @@ def run(cmd: list[str], cwd: pathlib.Path, timeout: int) -> subprocess.Completed
 
 
 def passes(pkg: pathlib.Path, level: int) -> bool:
-    result = run(['vendor/bin/phpstan', 'analyse', '-c', CONFIG,
-                  '-l', str(level), '--no-progress', '--error-format=raw', 'src'], pkg, 900)
+    # --memory-limit is explicit: PHPStan exhausts a 128M php.ini default on a
+    # package this size, and the crash reports as "Child process error (exit
+    # code 255) while running parallel worker" — which reads like a PHPStan bug
+    # and would be recorded as a failed level rather than an unmeasured one.
+    result = run(['vendor/bin/phpstan', 'analyse', '-c', CONFIG, '-l', str(level),
+                  '--memory-limit=1G', '--no-progress', '--error-format=raw', 'src'], pkg, 900)
     return result.returncode == 0
 
 

--- a/scripts/set-phpstan-levels
+++ b/scripts/set-phpstan-levels
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Write each measured PHPStan level into that package's tests.yml (step 6).
+
+The sibling of set-coverage-thresholds, and deliberately the same shape: the
+level a package is analysed at is a property of that repository, it is set from
+measured evidence rather than aspiration, and it only ever goes up.
+
+Reads storage/app/phpstan.tsv as written by measure-phpstan and edits the
+`with:` block of each repository's .github/workflows/tests.yml. Never lowers a
+level: a package whose measurement came back worse than its current setting
+keeps the setting and is reported, because that is a regression to look at
+rather than a number to relax.
+
+    set-phpstan-levels --workspace ~/code            # the package checkouts
+    set-phpstan-levels --workspace ~/code --dry-run
+    set-phpstan-levels --workspace ~/code --only search
+
+Never point this at modules/ or themes/ in the host. Those are Composer output;
+an edit there survives until the next composer update and is then silently lost.
+"""
+import argparse
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+TSV = ROOT / 'storage/app/phpstan.tsv'
+
+# The caller is a `uses:` line optionally followed by a `with:` block. Both the
+# coverage threshold and the level live in that block, so this has to add a key
+# to an existing block as often as it creates one — rewriting the file wholesale
+# is what silently reset every coverage threshold once.
+USES = re.compile(r'^(\s*)uses:\s*liberusoftware/\.github/\.github/workflows/package-tests\.yml@.*$', re.M)
+LEVEL_LINE = re.compile(r'^(\s*)phpstan-level:\s*(-?\d+)\s*$', re.M)
+
+
+def repository_for(workspace: pathlib.Path, name: str) -> pathlib.Path | None:
+    """Package name -> checkout. The GitHub repositories carry a prefix the Packagist names drop."""
+    for candidate in (f'module-{name}', f'theme-{name}', name):
+        target = workspace / candidate
+        if (target / '.git').is_dir():
+            return target
+    return None
+
+
+def apply(workflow: pathlib.Path, level: int, dry_run: bool) -> str:
+    body = workflow.read_text()
+
+    existing = LEVEL_LINE.search(body)
+    if existing:
+        current = int(existing.group(2))
+        if level <= current:
+            return f'kept {current} (measured {level})' + (' — REGRESSION' if level < current else '')
+        if dry_run:
+            return f'would raise {current} -> {level}'
+        workflow.write_text(LEVEL_LINE.sub(f'{existing.group(1)}phpstan-level: {level}', body, count=1))
+        return f'raised {current} -> {level}'
+
+    match = USES.search(body)
+    if not match:
+        return 'no package-tests.yml caller found'
+    indent = match.group(1)
+    if re.search(rf'^{indent}with:\s*$', body, re.M):
+        # A with: block already exists — coverage-threshold is usually in it.
+        addition = re.sub(rf'^({indent}with:\s*)$', rf'\1\n{indent}  phpstan-level: {level}', body, count=1, flags=re.M)
+    else:
+        addition = body[:match.end()] + f'\n{indent}with:\n{indent}  phpstan-level: {level}' + body[match.end():]
+    if dry_run:
+        return f'would set {level}'
+    workflow.write_text(addition)
+    return f'set {level}'
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(prog='set-phpstan-levels', description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--workspace', required=True, type=pathlib.Path,
+                        help='directory holding the package checkouts')
+    parser.add_argument('--only', nargs='+', metavar='NAME')
+    parser.add_argument('--dry-run', action='store_true')
+    args = parser.parse_args()
+
+    if not TSV.is_file():
+        print(f'{TSV} not found — run scripts/measure-phpstan first.', file=sys.stderr)
+        return 2
+
+    workspace = args.workspace.expanduser().resolve()
+    rows = []
+    for line in TSV.read_text().splitlines():
+        if not line.strip():
+            continue
+        fields = line.split('\t')
+        if len(fields) < 3 or fields[1] != 'ok':
+            rows.append((fields[0], None, fields[1] if len(fields) > 1 else 'malformed'))
+            continue
+        rows.append((fields[0], int(fields[2]), None))
+
+    if args.only:
+        rows = [r for r in rows if r[0] in args.only]
+
+    attention = []
+    for name, level, status in sorted(rows):
+        if level is None:
+            print(f'{name:<34}skipped — {status}')
+            attention.append(name)
+            continue
+        target = repository_for(workspace, name)
+        if target is None:
+            print(f'{name:<34}absent from {workspace}')
+            attention.append(name)
+            continue
+        workflow = target / '.github/workflows/tests.yml'
+        if not workflow.is_file():
+            print(f'{name:<34}no .github/workflows/tests.yml')
+            attention.append(name)
+            continue
+        result = apply(workflow, level, args.dry_run)
+        print(f'{name:<34}{result}')
+        if 'REGRESSION' in result or 'no package-tests.yml' in result:
+            attention.append(name)
+
+    if attention:
+        print(f'\n{len(attention)} of {len(rows)} need attention: {" ".join(sorted(attention))}', file=sys.stderr)
+    return 1 if attention else 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/themes/base/.github/workflows/tests.yml
+++ b/themes/base/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 100

--- a/themes/base/composer.json
+++ b/themes/base/composer.json
@@ -17,7 +17,7 @@
       "name": "base"
     }
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "require-dev": {
     "liberusoftware/package-testbench": "^1.5",
     "pestphp/pest": "^5.0"

--- a/themes/base/theme.json
+++ b/themes/base/theme.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.liberu.dev/theme/v1.json",
     "name": "base",
     "display_name": "Liberu Base",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "provider": "Liberu\\Themes\\Base\\BaseThemeServiceProvider",
     "type": "shared",
     "parent": null,

--- a/themes/clear-signal/.github/workflows/tests.yml
+++ b/themes/clear-signal/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 100

--- a/themes/clear-signal/composer.json
+++ b/themes/clear-signal/composer.json
@@ -18,7 +18,7 @@
       "name": "clear-signal"
     }
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "require-dev": {
     "liberusoftware/package-testbench": "^1.5",
     "pestphp/pest": "^5.0"

--- a/themes/clear-signal/theme.json
+++ b/themes/clear-signal/theme.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.liberu.dev/theme/v1.json",
     "name": "clear-signal",
     "display_name": "Clear Signal",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "provider": "Liberu\\Themes\\ClearSignal\\ClearSignalThemeServiceProvider",
     "type": "public",
     "parent": "base",

--- a/themes/dark/.github/workflows/tests.yml
+++ b/themes/dark/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 100

--- a/themes/dark/composer.json
+++ b/themes/dark/composer.json
@@ -18,7 +18,7 @@
       "name": "dark"
     }
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "require-dev": {
     "liberusoftware/package-testbench": "^1.5",
     "pestphp/pest": "^5.0"

--- a/themes/dark/theme.json
+++ b/themes/dark/theme.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.liberu.dev/theme/v1.json",
     "name": "dark",
     "display_name": "Liberu Dark",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "provider": "Liberu\\Themes\\Dark\\DarkThemeServiceProvider",
     "type": "public",
     "parent": "base",

--- a/themes/default/.github/workflows/tests.yml
+++ b/themes/default/.github/workflows/tests.yml
@@ -18,4 +18,5 @@ jobs:
   tests:
     uses: liberusoftware/.github/.github/workflows/package-tests.yml@main
     with:
+      phpstan-level: 10
       coverage-threshold: 100

--- a/themes/default/composer.json
+++ b/themes/default/composer.json
@@ -18,7 +18,7 @@
       "name": "default"
     }
   },
-  "version": "1.5.0",
+  "version": "1.5.1",
   "require-dev": {
     "liberusoftware/package-testbench": "^1.5",
     "pestphp/pest": "^5.0"

--- a/themes/default/theme.json
+++ b/themes/default/theme.json
@@ -2,7 +2,7 @@
     "$schema": "https://schemas.liberu.dev/theme/v1.json",
     "name": "default",
     "display_name": "Liberu Default",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "provider": "Liberu\\Themes\\DefaultTheme\\DefaultThemeServiceProvider",
     "type": "public",
     "parent": "base",


### PR DESCRIPTION
Static analysis reached **0 of 44 packages** when this started, while the host declared Larastan level 9 over five files that CI never ran. It now runs everywhere, and `docs/CODE-CONFORMANCE.md` records where the fleet stands against the code-level standards.

Charted and worked as [Wayfinder: audit boilerplate-laravel against the Liberu code-level standards](https://github.com/liberusoftware/boilerplate-laravel/issues/642) — eight tickets, all closed.

## What ships here

- **44 packages patch-released** with a measured, ratcheting `phpstan-level`; `modules/`, `themes/` and `composer.lock` updated together, as one wave.
- **`docs/CODE-CONFORMANCE.md`** — 37 findings over 122 audited rule clusters.
- **`CLAUDE.md`** gains a *Static analysis* section; `scripts/README.md` documents the two new scripts.
- **`scripts/measure-phpstan`** and **`scripts/set-phpstan-levels`**.

Outside this repository: `liberusoftware/package-testbench` **1.8.0** now carries Pint and Larastan as `require` plus both configs, and `liberusoftware/.github`'s `package-tests.yml` runs them.

## The measured baseline

44 of 44 measured, none failing level 0 — no package has an error that no level relaxes.

| Level | Packages |
| --- | --- |
| 10 | 11 |
| 9 / 8 | 1 / 1 |
| 5 | **18** |
| 4 / 3 / 2 | 2 / 1 / 2 |
| 1 | **8** |

The cluster at 5 is not a bisection artefact: level 6 is where PHPStan begins reporting missing type hints, and it is the fleet's modal wall. The eight at level 1 are where the real defects are.

## The findings that break a consumer

- **Seven packages call members their declared type does not have.** `jetstream-bridge` type-hints `Illuminate\Foundation\Auth\User` then calls `teams()`, `deleteProfilePhoto()`, `$connectedAccounts` — members only the host's `User` has, through traits it neither requires nor declares.
- **`search` returns a class that resolves to nothing** — a bare `User` in its own namespace.
- **`theme-support` cannot be analysed above level 1**, because booting it throws `Theme directory/name collision detected`.
- **Both `-livewire` packages register bare global aliases** instead of package-qualified ones, so a consumer registering the same name silently wins.

Four more **break a promise**, including `CONFORMANCE.md` §6 claiming no ADR exceptions while eight packages drop the `module-` prefix, and both analytics adapters being inert with nothing saying so.

**Nothing is fixed here.** Each of the 37 is its own decision, taken with the measurement in hand — which is what kept the audit from becoming the thing it was measuring.

## Three bugs caught before they shipped

1. The shared `phpstan.neon` could not load — PHPStan has no optional-include syntax, so a `?` prefix is read as part of the path. Would have failed all 44 on the first run.
2. PHPStan crashed on the 128M default and reported it as a parallel-worker error.
3. `fleet commit` broke on 9 of 44 repositories with `Argument list too long` — a repository with a committed `vendor/` stages ~10,000 paths into one `git reset`. Now chunked, deliberately keeping staged deletions.

## Verification

- Host suite: **203 passed**, 12 skipped, 0 failed.
- `vendor/bin/phpstan analyse`: **no errors** at the new level 5.
- **50 of 50** package repositories green after the wave.
- The §6.2 zero-diff gate runs in `install.yml` and will confirm a clean install reproduces the tracked `modules/` and `themes/`.

## Known, and not fixed here

Container DNS on the development host is intermittently broken, so Composer was run against pinned hosts resolved on the host. Those IPs are CDN-backed and will go stale — a workaround for running the sweep, not a fix.